### PR TITLE
Fix toast safari

### DIFF
--- a/preview/assets/theme.css
+++ b/preview/assets/theme.css
@@ -61,10 +61,11 @@ body {
 /* Modern browsers with `scrollbar-*` support */
 @supports (scrollbar-width: auto) {
   :not(:hover) {
-    scrollbar-color: rgba(0, 0, 0, 0) rgba(0, 0, 0, 0);
+    scrollbar-color: rgb(0 0 0 / 0%) rgb(0 0 0 / 0%);
   }
+
   :hover {
-    scrollbar-color: var(--contrast-background-color) rgba(0, 0, 0, 0);
+    scrollbar-color: var(--contrast-background-color) rgb(0 0 0 / 0%);
   }
 }
 

--- a/preview/src/components/toast/style.css
+++ b/preview/src/components/toast/style.css
@@ -7,10 +7,10 @@
 }
 
 .toast-list {
-  margin: 0;
-  padding: 0;
   display: flex;
   flex-direction: column-reverse;
+  padding: 0;
+  margin: 0;
   gap: 0.75rem;
 }
 

--- a/preview/src/components/toast/style.css
+++ b/preview/src/components/toast/style.css
@@ -3,10 +3,19 @@
   z-index: 9999;
   right: 20px;
   bottom: 20px;
-  display: flex;
   max-width: 350px;
+}
+
+.toast-list {
+  margin: 0;
+  padding: 0;
+  display: flex;
   flex-direction: column-reverse;
   gap: 0.75rem;
+}
+
+.toast-item {
+  display: flex;
 }
 
 .toast {

--- a/primitives/src/toast.rs
+++ b/primitives/src/toast.rs
@@ -191,12 +191,12 @@ pub fn ToastProvider(props: ToastProviderProps) -> Element {
                 },
 
                 ol {
-                    display: "contents",
+                    class: "toast-list",
                     // Render all toasts
                     for (index, toast) in toast_list.read().iter().rev().enumerate() {
                         li {
                             key: "{toast.id}",
-                            display: "contents",
+                            class: "toast-item",
                             {
                                 props.render_toast.call(ToastProps::builder().id(toast.id)
                                     .index(index)


### PR DESCRIPTION
Safari doesn't render `display: contents` correctly for toasts. This PR removes the usage that breaks safari

Fixes #63 