### PR TITLE
Fix focusing items as the context menu is closed

### DIFF
--- a/primitives/src/alert_dialog.rs
+++ b/primitives/src/alert_dialog.rs
@@ -6,7 +6,7 @@ use dioxus::prelude::*;
 
 #[derive(Clone)]
 struct AlertDialogCtx {
-    open: ReadOnlySignal<bool>,
+    open: Memo<bool>,
     set_open: Callback<bool>,
     labelledby: String,
     describedby: String,
@@ -86,7 +86,7 @@ pub fn AlertDialogRoot(props: AlertDialogRootProps) -> Element {
     });
     let open = use_memo(move || (props.open)().unwrap_or_else(&*open_signal));
     use_context_provider(|| AlertDialogCtx {
-        open: open.into(),
+        open,
         set_open,
         labelledby,
         describedby,

--- a/primitives/src/checkbox.rs
+++ b/primitives/src/checkbox.rs
@@ -52,7 +52,7 @@ impl Not for CheckboxState {
 
 #[derive(Clone, Copy)]
 struct CheckboxCtx {
-    checked: ReadOnlySignal<CheckboxState>,
+    checked: Memo<CheckboxState>,
     disabled: ReadOnlySignal<bool>,
 }
 
@@ -131,7 +131,7 @@ pub fn Checkbox(props: CheckboxProps) -> Element {
     );
 
     use_context_provider(|| CheckboxCtx {
-        checked: checked.into(),
+        checked,
         disabled: props.disabled,
     });
 

--- a/primitives/src/context_menu.rs
+++ b/primitives/src/context_menu.rs
@@ -9,7 +9,7 @@ use dioxus::prelude::*;
 #[derive(Clone, Copy)]
 struct ContextMenuCtx {
     // State
-    open: ReadOnlySignal<bool>,
+    open: Memo<bool>,
     set_open: Callback<bool>,
     disabled: ReadOnlySignal<bool>,
 
@@ -104,7 +104,7 @@ pub fn ContextMenu(props: ContextMenuProps) -> Element {
 
     let focus = use_focus_provider(props.roving_loop);
     let mut ctx = use_context_provider(|| ContextMenuCtx {
-        open: open.into(),
+        open,
         set_open,
         disabled: props.disabled,
         position,
@@ -466,10 +466,12 @@ pub fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
 
     let handle_click = {
         let value = (props.value)().clone();
-        move |_| {
+        move |event: Event<PointerData>| {
             if !disabled() {
                 props.on_select.call(value.clone());
                 ctx.focus.blur();
+                event.prevent_default();
+                event.stop_propagation();
             }
         }
     };

--- a/primitives/src/dropdown_menu.rs
+++ b/primitives/src/dropdown_menu.rs
@@ -11,7 +11,7 @@ use dioxus::prelude::*;
 #[derive(Clone, Copy)]
 struct DropdownMenuContext {
     // State
-    open: ReadOnlySignal<bool>,
+    open: Memo<bool>,
     set_open: Callback<bool>,
     disabled: ReadOnlySignal<bool>,
 
@@ -104,7 +104,7 @@ pub fn DropdownMenu(props: DropdownMenuProps) -> Element {
     let trigger_id = use_unique_id();
     let focus = use_focus_provider(props.roving_loop);
     let mut ctx = use_context_provider(|| DropdownMenuContext {
-        open: open.into(),
+        open,
         set_open,
         disabled,
         focus,

--- a/primitives/src/focus.rs
+++ b/primitives/src/focus.rs
@@ -188,7 +188,6 @@ impl FocusState {
         let is_focused = self.is_focused(index);
         if is_focused {
             if let Some(md) = controlled_ref() {
-                tracing::info!("Setting focus to item {}", index);
                 spawn(async move {
                     let _ = md.set_focus(true).await;
                 });

--- a/primitives/src/focus.rs
+++ b/primitives/src/focus.rs
@@ -188,6 +188,7 @@ impl FocusState {
         let is_focused = self.is_focused(index);
         if is_focused {
             if let Some(md) = controlled_ref() {
+                tracing::info!("Setting focus to item {}", index);
                 spawn(async move {
                     let _ = md.set_focus(true).await;
                 });

--- a/primitives/src/radio_group.rs
+++ b/primitives/src/radio_group.rs
@@ -12,7 +12,7 @@ use dioxus::prelude::*;
 struct RadioGroupCtx {
     // State
     disabled: ReadOnlySignal<bool>,
-    value: ReadOnlySignal<String>,
+    value: Memo<String>,
     set_value: Callback<String>,
 
     // Keyboard nav data
@@ -158,7 +158,7 @@ pub fn RadioGroup(props: RadioGroupProps) -> Element {
 
     let focus = use_focus_provider(props.roving_loop);
     let mut ctx = use_context_provider(|| RadioGroupCtx {
-        value: value.into(),
+        value,
         set_value,
         disabled: props.disabled,
 


### PR DESCRIPTION
There are two different bugs that were causing this:
1) We were using ReadOnlySignal<T> from the `Memo<T>` which doesn't recompute the value if it is dirty before the next async tick. This should be fixed by https://github.com/DioxusLabs/dioxus/pull/4413, but for now we can just use the memo directly
2) Clicking the item was focusing the item after the focus was set elsewhere. Then the menu was removed and the focus got kicked to the document. This PR calls `prevent_default` to stop the focus behavior

For reference, this is the reproduction of the issue:
```rust
use dioxus::prelude::*;
use dioxus_primitives::context_menu::*;

fn main() {
    dioxus::launch(App);
}

#[component]
pub fn App() -> Element {
    let mut mounted: Signal<Option<std::rc::Rc<MountedData>>> = use_signal(|| None);
    let mut count: Signal<usize> = use_signal(|| 0);

    rsx! {
        ContextMenu {
            ContextMenuTrigger {
                div { class: "p-2 rounded cursor-pointer", "something" }
            }
            ContextMenuContent { class: "context-menu-content",
                ContextMenuItem {
                    class: "context-menu-item",
                    index: 1usize,
                    on_select: move |_| {
                        if let Some(data) = mounted() {
                            _ = data.set_focus(true)
                        }
                    },
                    value: "remove",
                    "Focus"
                }
            }
        }
        button {
          onclick: move |_| {
              if let Some(data) = mounted() {
                  _ = data.set_focus(true);
              }
          },
          "Focus other"
        }
        button {
          onmounted: move |evt| {
              mounted.set(Some(evt.data()));
          },
          onclick: move |_| {
              count += 1;
          },
          "{count}"
        }
    }
}
```

Fixes #92