### PR TITLE
Add wasm32 target for cargo clippy with --all-targets in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,6 +118,7 @@ jobs:
           version: 1.0
       - uses: dtolnay/rust-toolchain@1.86.0
         with:
+          targets: wasm32-unknown-unknown
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Thus, we can ensure that some change is unintendedly incompatible with the wasm32 target.