### PR TITLE
Fix use_effect_cleanup on desktop

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -101,7 +101,7 @@ fn use_controlled<T: Clone + PartialEq>(
 
 /// Run some cleanup code when the component is unmounted if the effect was run.
 fn use_effect_cleanup<F: FnOnce() + 'static>(#[allow(unused)] cleanup: F) {
-    web!(crate::dioxus_core::use_drop(cleanup))
+    client!(crate::dioxus_core::use_drop(cleanup))
 }
 
 fn use_animated_open(


### PR DESCRIPTION
use_effect_cleanup should run on any renderer where effects run, but it is currently only running on the web client

Fixes #91 on desktop