### PR TITLE
Fix Copy btn not working everywhere

### DIFF
--- a/preview/src/main.rs
+++ b/preview/src/main.rs
@@ -245,7 +245,7 @@ fn CopyButton(#[props(extends=GlobalAttributes)] attributes: Vec<Attribute>) -> 
             class: "copy-button",
             aria_label: "Copy code",
             "data-copied": copied,
-            "onclick": "navigator.clipboard.writeText(this.parentNode.firstChild.innerText);",
+            "onclick": "navigator.clipboard.writeText(this.parentNode.firstChild.innerText || this.parentNode.innerText);",
             onclick: move |_| copied.set(true),
             ..attributes,
             if copied() {


### PR DESCRIPTION
The copy button did previously not work if the the first child is not an element but just text, like this:

```html
<parent>
"Text"
<Button/>
</parent>
```

This is the case with the Copy Button for the `cargo add ...` command on the start page. This now works for both cases.