### PR TITLE
Fix calendar month/year styling on safari

### DIFF
--- a/preview/src/components/calendar/variants/main/mod.rs
+++ b/preview/src/components/calendar/variants/main/mod.rs
@@ -1,6 +1,7 @@
 use dioxus::prelude::*;
 use dioxus_primitives::calendar::{
-    Calendar, CalendarContext, CalendarDate, CalendarGrid, CalendarHeader, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
+    Calendar, CalendarContext, CalendarDate, CalendarGrid, CalendarHeader, CalendarNavigation,
+    CalendarNextMonthButton, CalendarPreviousMonthButton,
 };
 
 #[component]
@@ -56,37 +57,67 @@ pub fn Demo() -> Element {
 #[component]
 fn MonthTitle() -> Element {
     let calendar: CalendarContext = use_context();
+    let view_date = calendar.view_date();
+    let month = view_date.month_abbreviation();
+    let year = view_date.year;
+
     rsx! {
-        select {
-            class: "calendar-month-select",
-            aria_label: "Month",
-            onchange: move |e| {
-                let mut view_date = calendar.view_date();
-                view_date.month = e.value().parse().unwrap_or(view_date.month);
-                calendar.set_view_date(view_date);
-            },
-            for (i, month) in CalendarDate::MONTH_ABBREVIATIONS.iter().enumerate() {
-                option {
-                    value: i + 1,
-                    selected: calendar.view_date().month == (i as u32 + 1),
-                    "{month}"
+        span {
+            class: "calendar-month-select-container",
+            select {
+                class: "calendar-month-select",
+                aria_label: "Month",
+                onchange: move |e| {
+                    let mut view_date = calendar.view_date();
+                    view_date.month = e.value().parse().unwrap_or(view_date.month);
+                    calendar.set_view_date(view_date);
+                },
+                for (i, month) in CalendarDate::MONTH_ABBREVIATIONS.iter().enumerate() {
+                    option {
+                        value: i + 1,
+                        selected: calendar.view_date().month == (i as u32 + 1),
+                        "{month}"
+                    }
+                }
+            }
+            span {
+                class: "calendar-month-select-value",
+                "{month}"
+                svg {
+                    class: "select-expand-icon",
+                    view_box: "0 0 24 24",
+                    xmlns: "http://www.w3.org/2000/svg",
+                    polyline { points: "6 9 12 15 18 9" }
                 }
             }
         }
 
-        select {
-            class: "calendar-year-select",
-            aria_label: "Year",
-            onchange: move |e| {
-                let mut view_date = calendar.view_date();
-                view_date.year = e.value().parse().unwrap_or(view_date.year);
-                calendar.set_view_date(view_date);
-            },
-            for year in 1925..=2050 {
-                option {
-                    value: year,
-                    selected: calendar.view_date().year == year,
-                    "{year}"
+        span {
+            class: "calendar-year-select-container",
+            select {
+                class: "calendar-year-select",
+                aria_label: "Year",
+                onchange: move |e| {
+                    let mut view_date = calendar.view_date();
+                    view_date.year = e.value().parse().unwrap_or(view_date.year);
+                    calendar.set_view_date(view_date);
+                },
+                for year in 1925..=2050 {
+                    option {
+                        value: year,
+                        selected: calendar.view_date().year == year,
+                        "{year}"
+                    }
+                }
+            }
+            span {
+                class: "calendar-year-select-value",
+                "{year}"
+                svg {
+                    class: "select-expand-icon",
+                    view_box: "0 0 24 24",
+                    xmlns: "http://www.w3.org/2000/svg",
+                    polyline { points: "6 9 12 15 18 9" }
                 }
             }
         }

--- a/preview/src/components/calendar/variants/main/style.css
+++ b/preview/src/components/calendar/variants/main/style.css
@@ -154,22 +154,45 @@
   stroke-width: 2;
 }
 
+.calendar-month-select-container, .calendar-year-select-container {
+  position: relative;
+}
+
+.calendar-month-select-container:has(:focus-visible), .calendar-year-select-container:has(:focus-visible) {
+  outline: 2px solid var(--focused-border-color);
+  border-radius: 0.5rem;
+}
+
+
 .calendar-month-select, .calendar-year-select {
-  /* border: 1px solid var(--primary-color-6); */
+  opacity: 0;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  position: absolute;
+  padding: .25rem;
+}
+
+.calendar-month-select-value, .calendar-year-select-value {
   border: none;
   background-color: transparent;
   color: var(--secondary-color-4);
-  padding: .25rem;
-  border-radius: 0.5rem;
   cursor: pointer;
   font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .25rem;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.calendar-month-select:hover, .calendar-year-select:hover {
-  background-color: var(--primary-color-4);
-}
-
-.calendar-month-select:focus-visible, .calendar-year-select:focus-visible {
-  box-shadow: 0 0 0 2px var(--focused-border-color);
+.select-expand-icon {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: var(--secondary-color-4);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
 }


### PR DESCRIPTION
On safari, the select element for the calendar dropdown currently has a gradient that looks out of place. This PR fixes the issue by making the select element a transparent overlay for interactions