### PR TITLE
Fix dropdown menu item mouse events

### DIFF
--- a/primitives/src/dropdown_menu.rs
+++ b/primitives/src/dropdown_menu.rs
@@ -323,6 +323,14 @@ pub fn DropdownMenuContent(props: DropdownMenuContentProps) -> Element {
                 role: "listbox",
                 aria_labelledby: "{ctx.trigger_id}",
                 "data-state": if (ctx.open)() { "open" } else { "closed" },
+                onmousedown: move |event: Event<MouseData>| {
+                    // The user is starting a click inside the dropdown menu.
+                    // Prevent the blur event from occuring during mousedown
+                    // to keep the dropdown menu open until mouseup happens,
+                    // thus enabling onclick/onselect events to fire.
+                    event.prevent_default();
+                    event.stop_propagation();
+                },
                 ..props.attributes,
                 {props.children}
             }


### PR DESCRIPTION
This commit fixes an issue where dropdown menu items could not be clicked with a mouse, because the menu would close before the click event could complete.

This was fixed by preventing blur from happening during mousedown and have it occur after mouseup instead, thus allowing click events to be fired.

## Testing

**Dioxus Primitives:** 04134aedc7fcc99e774fbf38c1360043a1105ddc

**Browsers:**
- Safari 18.6 
- Firefox 141.0.3

**Steps:**
1. Run preview app (`dx serve -p preview --platform web`)
2. Navigate to dropdown menu page (`/component/?name=dropdown_menu`)
3. Click on the "Open Menu" button
4. Click on any item
5. Check the logs from the dx command, and ensure there is a log in the format "Selected: {value}", indicating the `on_select` event was triggered by the click.
6. Try triggering the menu items using the keyboard and ensure the corresponding logs appear
7. Try clicking outside the dropdown menu once it is open, ensure the menu gets closed.

**Results:** Works as expected
