### PR TITLE
Update slider default value to 50.0

### DIFF
--- a/preview/src/components/slider/variants/main/mod.rs
+++ b/preview/src/components/slider/variants/main/mod.rs
@@ -4,7 +4,7 @@ use dioxus_primitives::slider::SliderValue;
 
 #[component]
 pub fn Demo() -> Element {
-    let mut current_value = use_signal(|| 0.5);
+    let mut current_value = use_signal(|| 50.0);
 
     rsx! {
         // Display the current value


### PR DESCRIPTION
Changed the initial value of the slider in the Demo component from 0.5 to 50.0 to better reflect the intended starting point.

Before
<img width="321" height="372" alt="image" src="https://github.com/user-attachments/assets/d76920fc-927b-49f3-b629-3d2fda0a61bb" />

After:
<img width="334" height="379" alt="image" src="https://github.com/user-attachments/assets/fc8ecfc9-1ddf-4d4b-aa21-e810703c050a" />
