### PR TITLE
Fix sheet component example

### DIFF
--- a/preview/src/components/sheet/component.rs
+++ b/preview/src/components/sheet/component.rs
@@ -139,7 +139,7 @@ pub fn SheetDescription(props: DialogDescriptionProps) -> Element {
 pub fn SheetClose(
     #[props(extends = GlobalAttributes)] attributes: Vec<Attribute>,
     r#as: Option<Callback<Vec<Attribute>, Element>>,
-    children: Option<Element>,
+    children: Element,
 ) -> Element {
     let ctx: DialogCtx = use_context();
 


### PR DESCRIPTION
Now compiles without the error on newer dx
```
expected `Option<Result<VNode, RenderError>>`, found `Result<VNode, RenderError>`
   |
   = note: expected enum `std::option::Option<std::result::Result<_, _>>`
              found enum `std::result::Result<_, _>`
   = note: this error originates in the derive macro `Props` (in Nightly builds, run with -Z macro-backtrace for more info)
```
@ealmloff  https://discord.com/channels/899851952891002890/943190605067079712/1450225909931184200