### PR TITLE
Select Options disalbed rework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ version = "0.0.1"
 dependencies = [
  "dioxus",
  "dioxus-sdk-time",
+ "indexmap",
  "lazy-js-bundle 0.6.2",
  "num-integer",
  "time",
@@ -3680,9 +3681,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -4172,12 +4173,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4548,7 +4549,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]

--- a/playwright/select.spec.ts
+++ b/playwright/select.spec.ts
@@ -5,10 +5,10 @@ test("test", async ({ page }) => {
         timeout: 20 * 60 * 1000,
     }); // Increase timeout to 20 minutes
     // Find Select a fruit...
-    let selectTrigger = page.locator(".select-trigger");
+    let selectTrigger = page.locator("#select-main .select-trigger");
     await selectTrigger.click();
     // Assert the select menu is open
-    const selectMenu = page.locator(".select-list");
+    const selectMenu = page.locator("#select-main .select-list");
     await expect(selectMenu).toHaveAttribute("data-state", "open");
 
     // Assert the menu is focused
@@ -64,10 +64,10 @@ test("test", async ({ page }) => {
 test("tabbing out of menu closes the select menu", async ({ page }) => {
     await page.goto("http://127.0.0.1:8080/component/?name=select&");
     // Find Select a fruit...
-    let selectTrigger = page.locator(".select-trigger");
+    let selectTrigger = page.locator("#select-main .select-trigger");
     await selectTrigger.click();
     // Assert the select menu is open
-    const selectMenu = page.locator(".select-list");
+    const selectMenu = page.locator("#select-main .select-list");
     await expect(selectMenu).toHaveAttribute("data-state", "open");
 
     // Assert the menu is focused
@@ -80,10 +80,10 @@ test("tabbing out of menu closes the select menu", async ({ page }) => {
 test("tabbing out of item closes the select menu", async ({ page }) => {
     await page.goto("http://127.0.0.1:8080/component/?name=select&");
     // Find Select a fruit...
-    let selectTrigger = page.locator(".select-trigger");
+    let selectTrigger = page.locator("#select-main .select-trigger");
     await selectTrigger.click();
     // Assert the select menu is open
-    const selectMenu = page.locator(".select-list");
+    const selectMenu = page.locator("#select-main .select-list");
     await expect(selectMenu).toHaveAttribute("data-state", "open");
 
     // Assert the menu is focused
@@ -101,10 +101,10 @@ test("tabbing out of item closes the select menu", async ({ page }) => {
 test("options selected", async ({ page }) => {
     await page.goto("http://127.0.0.1:8080/component/?name=select&");
     // Find Select a fruit...
-    let selectTrigger = page.locator(".select-trigger");
+    let selectTrigger = page.locator("#select-main .select-trigger");
     await selectTrigger.click();
     // Assert the select menu is open
-    const selectMenu = page.locator(".select-list");
+    const selectMenu = page.locator("#select-main .select-list");
     await expect(selectMenu).toHaveAttribute("data-state", "open");
 
     // Assert no items have aria-selected
@@ -130,25 +130,126 @@ test("options selected", async ({ page }) => {
 test("down arrow selects first element", async ({ page }) => {
     await page.goto("http://127.0.0.1:8080/component/?name=select&");
     // Find Select a fruit...
-    let selectTrigger = page.locator(".select-trigger");
-    const selectMenu = page.locator(".select-list");
+    let selectTrigger = page.locator("#select-main .select-trigger");
+    const selectMenu = page.locator("#select-main .select-list");
     await selectTrigger.focus();
 
     // Select the first option
     await page.keyboard.press("ArrowDown");
     const firstOption = selectMenu.getByRole("option", { name: "apple" });
     await expect(firstOption).toBeFocused();
+
+    // Same thing but with the first option disabled
+    let disabledSelectTrigger = page.locator("#select-disabled .select-trigger");
+    const disabledSelectMenu = page.locator("#select-disabled .select-list");
+    await disabledSelectTrigger.focus();
+    await page.keyboard.press("ArrowDown");
+    const disabledFirstOption = disabledSelectMenu.getByRole("option", { name: "banana" });
+    await expect(disabledFirstOption).toBeFocused();
 });
 
 test("up arrow selects last element", async ({ page }) => {
     await page.goto("http://127.0.0.1:8080/component/?name=select&");
     // Find Select a fruit...
-    let selectTrigger = page.locator(".select-trigger");
-    const selectMenu = page.locator(".select-list");
+    let selectTrigger = page.locator("#select-main .select-trigger");
+    const selectMenu = page.locator("#select-main .select-list");
     await selectTrigger.focus();
 
     // Select the first option
     await page.keyboard.press("ArrowUp");
-    const firstOption = selectMenu.getByRole("option", { name: "other" });
+    const lastOption = selectMenu.getByRole("option", { name: "other" });
+    await expect(lastOption).toBeFocused();
+
+    // Same thing but with the last option disabled
+    let disabledSelectTrigger = page.locator("#select-disabled .select-trigger");
+    const disabledSelectMenu = page.locator("#select-disabled .select-list");
+    await disabledSelectTrigger.focus();
+
+    await page.keyboard.press("ArrowUp");
+    const disabledLastOption = disabledSelectMenu.getByRole("option", { name: "watermelon" });
+    await expect(disabledLastOption).toBeFocused();
+});
+
+test("rollover on top and bottom", async ({ page }) => {
+    await page.goto("http://127.0.0.1:8080/component/?name=select&");
+
+    // Find Select a fruit...
+    let selectTrigger = page.locator("#select-main .select-trigger");
+    const selectMenu = page.locator("#select-main .select-list");
+    await selectTrigger.focus();
+
+    // open the list and select first option
+    await page.keyboard.press("ArrowDown");
+    const firstOption = selectMenu.getByRole("option", { name: "apple" });
     await expect(firstOption).toBeFocused();
+
+    // up arrow to select last option (rollover)
+    await page.keyboard.press("ArrowUp");
+    const lastOption = selectMenu.getByRole("option", { name: "other" });
+    await expect(lastOption).toBeFocused();
+
+    // down arrow to select first option (rollover)
+    await page.keyboard.press("ArrowDown");
+    await expect(firstOption).toBeFocused();
+
+    // Same thing but with first and last options disabled
+    let disabledSelectTrigger = page.locator("#select-disabled .select-trigger");
+    const disabledSelectMenu = page.locator("#select-disabled .select-list");
+    await disabledSelectTrigger.focus();
+
+    // open the list and select first option
+    await page.keyboard.press("ArrowDown");
+    const disabledFirstOption = disabledSelectMenu.getByRole("option", { name: "banana" });
+    await expect(disabledFirstOption).toBeFocused();
+
+    // up arrow to select last option (rollover)
+    await page.keyboard.press("ArrowUp");
+    const disabledLastOption = disabledSelectMenu.getByRole("option", { name: "watermelon" });
+    await expect(disabledLastOption).toBeFocused();
+
+    // down arrow to select first option (rollover)
+    await page.keyboard.press("ArrowDown");
+    await expect(disabledFirstOption).toBeFocused();
+});
+
+test("disabled elements are skipped", async ({ page }) => {
+    await page.goto("http://127.0.0.1:8080/component/?name=select&");
+
+    // Find Select a fruit...
+    let selectTrigger = page.locator("#select-disabled .select-trigger");
+    const selectMenu = page.locator("#select-disabled .select-list");
+    await selectTrigger.focus();
+
+    // open the list and select first enabled option
+    await page.keyboard.press("ArrowDown");
+    const firstOption = selectMenu.getByRole("option", { name: "banana" });
+    await expect(firstOption).toBeFocused();
+
+    // down arrow to select second enabled option
+    await page.keyboard.press("ArrowDown");
+    const secondOption = selectMenu.getByRole("option", { name: "strawberry" });
+    await expect(secondOption).toBeFocused();
+
+    // up arrow to select first enabled option
+    await page.keyboard.press("ArrowUp");
+    await expect(firstOption).toBeFocused();
+});
+
+test("aria active descendant", async ({ page }) => {
+    await page.goto("http://127.0.0.1:8080/component/?name=select&");
+
+    // Find Select a fruit...
+    let selectTrigger = page.locator("#select-main .select-trigger");
+    const selectMenu = page.locator("#select-main .select-list");
+    await selectTrigger.focus();
+
+    // select first option
+    await page.keyboard.press("ArrowDown");
+    const firstOption = selectMenu.getByRole("option", { name: "apple" });
+    await expect(selectTrigger).toHaveAttribute("aria-activedescendant", await firstOption.getAttribute("id"));
+
+    // select second option
+    await page.keyboard.press("ArrowDown");
+    const secondOption = selectMenu.getByRole("option", { name: "banana" });
+    await expect(selectTrigger).toHaveAttribute("aria-activedescendant", await secondOption.getAttribute("id"));
 });

--- a/preview/src/components/mod.rs
+++ b/preview/src/components/mod.rs
@@ -79,7 +79,7 @@ examples!(
     progress,
     radio_group,
     scroll_area,
-    select,
+    select[disabled],
     separator,
     skeleton,
     sheet,

--- a/preview/src/components/select/component.rs
+++ b/preview/src/components/select/component.rs
@@ -92,7 +92,7 @@ pub fn SelectOption<T: Clone + PartialEq + 'static>(props: SelectOptionProps<T>)
             text_value: props.text_value,
             disabled: props.disabled,
             id: props.id,
-            index: props.index,
+            tab_index: props.tab_index,
             aria_label: props.aria_label,
             aria_roledescription: props.aria_roledescription,
             attributes: props.attributes,

--- a/preview/src/components/select/style.css
+++ b/preview/src/components/select/style.css
@@ -133,6 +133,7 @@
 .select-option[data-disabled="true"] {
   color: var(--secondary-color-5);
   cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .select-option:hover:not([data-disabled="true"]),
@@ -147,9 +148,4 @@
   padding: 4px 12px;
   color: var(--secondary-color-5);
   font-size: 0.75rem;
-}
-
-[data-disabled="true"] {
-  cursor: not-allowed;
-  opacity: 0.5;
 }

--- a/preview/src/components/select/variants/disabled/mod.rs
+++ b/preview/src/components/select/variants/disabled/mod.rs
@@ -21,13 +21,25 @@ impl Fruit {
             Fruit::Watermelon => "🍉",
         }
     }
+
+    const fn disabled(&self) -> bool {
+        match self {
+            Fruit::Apple => true,
+            Fruit::Orange => true,
+            _ => false
+        }
+    }
 }
 
 #[component]
 pub fn Demo() -> Element {
     let fruits = Fruit::iter().enumerate().map(|(i, f)| {
         rsx! {
-            SelectOption::<Option<Fruit>> { index: i, value: f, text_value: "{f}",
+            SelectOption::<Option<Fruit>> {
+                index: i,
+                value: f,
+                text_value: "{f}",
+                disabled: f.disabled(),
                 {format!("{} {f}", f.emoji())}
                 SelectItemIndicator {}
             }
@@ -35,8 +47,7 @@ pub fn Demo() -> Element {
     });
 
     rsx! {
-
-        Select::<Option<Fruit>> { id: "select-main", placeholder: "Select a fruit...",
+        Select::<Option<Fruit>> { id: "select-disabled", placeholder: "Select a fruit...",
             SelectTrigger { aria_label: "Select Trigger", width: "12rem", SelectValue {} }
             SelectList { aria_label: "Select Demo",
                 SelectGroup {
@@ -49,6 +60,7 @@ pub fn Demo() -> Element {
                         index: Fruit::COUNT,
                         value: None,
                         text_value: "Other",
+                        disabled: true,
                         "Other"
                         SelectItemIndicator {}
                     }

--- a/preview/src/components/select/variants/disabled/mod.rs
+++ b/preview/src/components/select/variants/disabled/mod.rs
@@ -36,7 +36,7 @@ pub fn Demo() -> Element {
     let fruits = Fruit::iter().enumerate().map(|(i, f)| {
         rsx! {
             SelectOption::<Option<Fruit>> {
-                index: i,
+                tab_index: i,
                 value: f,
                 text_value: "{f}",
                 disabled: f.disabled(),
@@ -57,7 +57,7 @@ pub fn Demo() -> Element {
                 SelectGroup {
                     SelectGroupLabel { "Other" }
                     SelectOption::<Option<Fruit>> {
-                        index: Fruit::COUNT,
+                        tab_index: Fruit::COUNT,
                         value: None,
                         text_value: "Other",
                         disabled: true,

--- a/preview/src/components/select/variants/main/mod.rs
+++ b/preview/src/components/select/variants/main/mod.rs
@@ -27,7 +27,7 @@ impl Fruit {
 pub fn Demo() -> Element {
     let fruits = Fruit::iter().enumerate().map(|(i, f)| {
         rsx! {
-            SelectOption::<Option<Fruit>> { index: i, value: f, text_value: "{f}",
+            SelectOption::<Option<Fruit>> { tab_index: i, value: f, text_value: "{f}",
                 {format!("{} {f}", f.emoji())}
                 SelectItemIndicator {}
             }
@@ -46,7 +46,7 @@ pub fn Demo() -> Element {
                 SelectGroup {
                     SelectGroupLabel { "Other" }
                     SelectOption::<Option<Fruit>> {
-                        index: Fruit::COUNT,
+                        tab_index: Fruit::COUNT,
                         value: None,
                         text_value: "Other",
                         "Other"

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -17,6 +17,7 @@ dioxus-sdk-time = "0.7.0"
 time = { version = "0.3.41", features = ["std", "macros", "parsing"] }
 num-integer = "0.1.46"
 tracing.workspace = true
+indexmap = "2.12.1"
 
 [build-dependencies]
 lazy-js-bundle = "0.6.2"

--- a/primitives/src/context_menu.rs
+++ b/primitives/src/context_menu.rs
@@ -463,7 +463,7 @@ pub fn ContextMenuItem(props: ContextMenuItemProps) -> Element {
     let focused = move || ctx.focus.is_focused(props.index.cloned());
 
     // Handle settings focus
-    let onmounted = use_focus_controlled_item(props.index);
+    let onmounted = use_focus_controlled_item(props.index.cloned(), props.index);
 
     // Determine if this item is currently focused
     let tab_index = use_memo(move || if focused() { "0" } else { "-1" });

--- a/primitives/src/date_picker.rs
+++ b/primitives/src/date_picker.rs
@@ -550,7 +550,7 @@ fn DateSegment<T: Clone + Copy + Integer + FromStr + Display + 'static>(
         }
     };
 
-    let onmounted = use_focus_controlled_item(props.index);
+    let onmounted = use_focus_controlled_item(props.index.cloned(), props.index);
 
     let span_id = use_unique_id();
     let id = use_memo(move || format!("span-{span_id}"));

--- a/primitives/src/dropdown_menu.rs
+++ b/primitives/src/dropdown_menu.rs
@@ -416,7 +416,7 @@ pub fn DropdownMenuItem<T: Clone + PartialEq + 'static>(
     let disabled = move || (ctx.disabled)() || (props.disabled)();
     let focused = move || ctx.focus.is_focused((props.index)());
 
-    let onmounted = use_focus_controlled_item(props.index);
+    let onmounted = use_focus_controlled_item(props.index.cloned(), props.index);
 
     rsx! {
         div {

--- a/primitives/src/focus.rs
+++ b/primitives/src/focus.rs
@@ -1,67 +1,72 @@
-use std::rc::Rc;
-
-use dioxus::prelude::*;
-
 use crate::use_effect_cleanup;
+use dioxus::prelude::*;
+use indexmap::IndexMap;
+use std::ops::ControlFlow;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 pub(crate) fn use_focus_provider(roving_loop: ReadSignal<bool>) -> FocusState {
     use_context_provider(|| {
-        let item_count = Signal::new(0);
         let recent_focus = Signal::new(None);
         let current_focus = Signal::new(None);
+        let items = Signal::new(IndexMap::new());
 
         FocusState {
-            item_count,
             recent_focus,
             current_focus,
             roving_loop,
+            items,
         }
     })
 }
 
+/// If you don't already have a unique id, use this hook to generate one.
+pub(crate) fn use_focus_unique_id() -> usize {
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+    #[allow(unused_mut)]
+    let mut initial_value = use_hook(|| NEXT_ID.fetch_add(1, Ordering::Relaxed));
+
+    fullstack! {
+        let server_id = dioxus::prelude::use_server_cached(move || {
+            initial_value
+        });
+        initial_value = server_id;
+    }
+    initial_value
+}
+
 pub(crate) fn use_focus_entry(
     ctx: FocusState,
-    index: impl Readable<Target = usize> + Copy + 'static,
+    id: usize,
+    tab_index: impl Readable<Target = usize> + Copy + 'static,
 ) {
     let disabled = use_signal(|| false);
-    use_focus_entry_disabled(ctx, index, disabled);
+    use_focus_entry_disabled(ctx, id, tab_index, disabled);
 }
 
 pub(crate) fn use_focus_entry_disabled(
     mut ctx: FocusState,
-    index: impl Readable<Target = usize> + Copy + 'static,
-    disabled: impl Readable<Target = bool> + 'static,
+    id: usize,
+    tab_index: impl Readable<Target = usize> + Copy + 'static,
+    disabled: impl Readable<Target = bool> + Copy + 'static,
 ) {
-    let mut item = use_hook(|| CopyValue::new(false));
     use_effect(move || {
-        if disabled.cloned() {
-            if item.cloned() {
-                ctx.remove_item(index.cloned());
-                item.set(false);
-            }
-        } else {
-            ctx.add_item();
-            item.set(true);
-        }
+        ctx.add_update_item(id, tab_index, disabled);
     });
     use_effect_cleanup(move || {
-        if item.cloned() {
-            ctx.remove_item(index.cloned());
-        }
-    });
+        ctx.remove_item(id);
+    })
 }
 
-pub(crate) fn use_focus_control(
-    ctx: FocusState,
-    index: impl Readable<Target = usize> + Copy + 'static,
-) -> impl FnMut(MountedEvent) {
+pub(crate) fn use_focus_control(ctx: FocusState, id: usize) -> impl FnMut(MountedEvent) {
     let disabled = use_signal(|| false);
-    use_focus_control_disabled(ctx, index, disabled)
+    use_focus_control_disabled(ctx, id, disabled)
 }
 
 pub(crate) fn use_focus_control_disabled(
     ctx: FocusState,
-    index: impl Readable<Target = usize> + Copy + 'static,
+    id: usize,
     disabled: impl Readable<Target = bool> + 'static,
 ) -> impl FnMut(MountedEvent) {
     let mut controlled_ref: Signal<Option<Rc<MountedData>>> = use_signal(|| None);
@@ -69,34 +74,46 @@ pub(crate) fn use_focus_control_disabled(
         if disabled.cloned() {
             return;
         }
-        ctx.control_mount_focus(index.cloned(), controlled_ref);
+        ctx.control_mount_focus(id, controlled_ref);
     });
 
     move |data: Event<MountedData>| controlled_ref.set(Some(data.data()))
 }
 
 pub(crate) fn use_focus_controlled_item(
+    id: usize,
     index: impl Readable<Target = usize> + Copy + 'static,
 ) -> impl FnMut(MountedEvent) {
     let disabled = use_signal(|| false);
-    use_focus_controlled_item_disabled(index, disabled)
+    use_focus_controlled_item_disabled(id, index, disabled)
 }
 
 pub(crate) fn use_focus_controlled_item_disabled(
+    id: usize,
     index: impl Readable<Target = usize> + Copy + 'static,
     disabled: impl Readable<Target = bool> + Copy + 'static,
 ) -> impl FnMut(MountedEvent) {
     let ctx: FocusState = use_context();
-    use_focus_entry_disabled(ctx, index, disabled);
-    use_focus_control_disabled(ctx, index, disabled)
+    use_focus_entry_disabled(ctx, id, index, disabled);
+    use_focus_control_disabled(ctx, id, disabled)
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FocusStateElem {
+    pub(crate) tab_index: usize,
+    pub(crate) disabled: bool,
 }
 
 #[derive(Clone, Copy)]
 pub(crate) struct FocusState {
     pub(crate) roving_loop: ReadSignal<bool>,
-    pub(crate) item_count: Signal<usize>,
+    /// Recent focus is only None if this State is created.
+    /// It will normally hold the last focused item, even when no item is currently focused.
+    /// Similar to current_focus this holds the key into the map.
     pub(crate) recent_focus: Signal<Option<usize>>,
+    /// Key into the map that is currently focused.
     pub(crate) current_focus: Signal<Option<usize>>,
+    pub(crate) items: Signal<IndexMap<usize, FocusStateElem>>,
 }
 
 impl FocusState {
@@ -107,42 +124,113 @@ impl FocusState {
         self.current_focus.set(index);
     }
 
-    pub(crate) fn focus_next(&mut self) {
-        let current_focus = self.recent_focus();
-        let mut new_focus = current_focus
-            .map(|x| x.saturating_add(1))
-            .unwrap_or_default();
+    fn current_index(&self) -> Option<usize> {
+        let current_focus = self.current_focus()?;
 
-        let item_count = (self.item_count)();
-        if new_focus >= item_count {
-            match (self.roving_loop)() {
-                true => new_focus = 0,
-                false => new_focus = item_count.saturating_sub(1),
+        self.items.read().get_index_of(&current_focus)
+    }
+
+    fn focus_enabled(&mut self, index: usize, reverse: bool) {
+        let Self {
+            items,
+            roving_loop,
+            recent_focus,
+            current_focus,
+        } = self;
+        let items = items.read();
+
+        let (range1, range2) = if !reverse {
+            (index + 1..items.len(), 0..index)
+        } else {
+            (0..index, index + 1..items.len())
+        };
+
+        let iter = items.get_range(range1).into_iter().flat_map(|x| x.iter());
+
+        let iter2 = roving_loop()
+            .then(|| items.get_range(range2).into_iter().flat_map(|x| x.iter()))
+            .into_iter()
+            .flatten();
+
+        let it = |(&key, value): (&usize, &FocusStateElem)| {
+            if !value.disabled {
+                recent_focus.set(Some(key));
+                current_focus.set(Some(key));
+                return ControlFlow::Break(());
             }
-        }
+            ControlFlow::Continue(())
+        };
 
-        self.set_focus(Some(new_focus));
+        if !reverse {
+            let _ = iter.chain(iter2).try_for_each(it);
+        } else {
+            let _ = iter2.chain(iter).rev().try_for_each(it);
+        }
+    }
+
+    pub(crate) fn focus_next(&mut self) {
+        let index = match self.current_index() {
+            Some(x) => x,
+            None => return self.focus_first(),
+        };
+
+        self.focus_enabled(index, false);
     }
 
     pub(crate) fn focus_prev(&mut self) {
-        let current_focus = self.recent_focus();
-        let mut new_focus = current_focus
-            .map(|x| x.saturating_sub(1))
-            .unwrap_or_default();
-        if current_focus.unwrap_or_default() == 0 && (self.roving_loop)() {
-            new_focus = (self.item_count)().saturating_sub(1);
-        }
+        let index = match self.current_index() {
+            Some(x) => x,
+            None => return self.focus_last(),
+        };
 
-        self.set_focus(Some(new_focus));
+        self.focus_enabled(index, true);
     }
 
     pub(crate) fn focus_first(&mut self) {
-        self.set_focus(Some(0));
+        let key = {
+            self.items
+                .read()
+                .iter()
+                .filter(|(_, value)| !value.disabled)
+                .map(|(&key, _)| key)
+                .next()
+        };
+        if let Some(key) = key {
+            self.set_focus(Some(key));
+        }
     }
 
     pub(crate) fn focus_last(&mut self) {
-        let last_index = self.item_count.cloned() - 1;
-        self.set_focus(Some(last_index));
+        let key = {
+            self.items
+                .read()
+                .iter()
+                .rev()
+                .filter(|(_, value)| !value.disabled)
+                .map(|(&key, _)| key)
+                .next()
+        };
+        if let Some(key) = key {
+            self.set_focus(Some(key));
+        }
+    }
+
+    // pub(crate) fn focus_recent_or_first(&mut self) {
+    //     if let Some(id) = self.recent_focus() {
+    //         self.current_focus.set(Some(id));
+    //     } else {
+    //         self.focus_first();
+    //     }
+    // }
+
+    pub(crate) fn focus_recent_or_first(&mut self) {
+        if let Some(id) = self.recent_focus() {
+            if self.items.peek().contains_key(&id) {
+                self.current_focus.set(Some(id));
+                return;
+            }
+        }
+        self.focus_first();
     }
 
     pub(crate) fn blur(&mut self) {
@@ -165,31 +253,67 @@ impl FocusState {
         (self.recent_focus)()
     }
 
-    pub(crate) fn recent_focus_or_default(&self) -> usize {
-        (self.recent_focus)().unwrap_or_default()
-    }
+    /// `id`: The unique ID of the item to be added. I suggest using props.id here.
+    /// This code also runs when the tab_index or disabled changes
+    pub(crate) fn add_update_item(
+        &mut self,
+        id: usize,
+        tab_index: impl Readable<Target = usize> + Copy + 'static,
+        disabled: impl Readable<Target = bool> + Copy + 'static,
+    ) {
+        let tab_index = tab_index.cloned();
+        let disabled = disabled.cloned();
 
-    pub(crate) fn add_item(&mut self) {
-        self.item_count += 1;
+        {
+            // update item if it already exists
+            let mut items = self.items.write();
+            let item = items.get_mut(&id);
+            if let Some(item) = item {
+                item.disabled = disabled;
+                let changed = item.tab_index != tab_index;
+                item.tab_index = tab_index;
+
+                // if the tab_index didn't change, we don't need to refresh its order.
+                if !changed {
+                    return;
+                }
+            }
+        }
+
+        let index = self
+            .items
+            .peek()
+            .partition_point(|_, value| value.tab_index <= tab_index);
+
+        self.items.write().insert_before(
+            index,
+            id,
+            FocusStateElem {
+                tab_index,
+                disabled,
+            },
+        );
     }
 
     pub(crate) fn item_count(&self) -> usize {
-        self.item_count.cloned()
+        self.items.read().len()
     }
 
-    pub(crate) fn remove_item(&mut self, index: usize) {
-        self.item_count -= 1;
-        if (self.current_focus)() == Some(index) {
-            self.set_focus(None);
+    pub(crate) fn remove_item(&mut self, id: usize) {
+        let elem = self.items.write().shift_remove_full(&id);
+        if let Some((_, key, _)) = elem {
+            if (self.current_focus)() == Some(key) {
+                self.set_focus(None);
+            }
         }
     }
 
     pub(crate) fn control_mount_focus(
         &self,
-        index: usize,
+        id: usize,
         controlled_ref: Signal<Option<Rc<MountedData>>>,
     ) {
-        let is_focused = self.is_focused(index);
+        let is_focused = self.is_focused(id);
         if is_focused {
             if let Some(md) = controlled_ref() {
                 spawn(async move {

--- a/primitives/src/radio_group.rs
+++ b/primitives/src/radio_group.rs
@@ -286,7 +286,8 @@ pub fn RadioItem(props: RadioItemProps) -> Element {
         "-1"
     });
 
-    let onmounted = use_focus_controlled_item_disabled(props.index, props.disabled);
+    let onmounted =
+        use_focus_controlled_item_disabled(props.index.cloned(), props.index, props.disabled);
 
     rsx! {
         button {

--- a/primitives/src/select/components/group.rs
+++ b/primitives/src/select/components/group.rs
@@ -173,7 +173,7 @@ pub fn SelectGroupLabel(props: SelectGroupLabelProps) -> Element {
     let render = use_context::<SelectListContext>().render;
 
     rsx! {
-        if render () {
+        if render() {
             div {
                 // Set the ID for the label
                 id,

--- a/primitives/src/select/components/group.rs
+++ b/primitives/src/select/components/group.rs
@@ -53,13 +53,13 @@ pub struct SelectGroupProps {
 ///                 SelectGroup {
 ///                     SelectGroupLabel { "Fruits" }
 ///                     SelectOption::<String> {
-///                         index: 0usize,
+///                         tab_index: 0usize,
 ///                         value: "apple",
 ///                         "Apple"
 ///                         SelectItemIndicator { "✔️" }
 ///                     }
 ///                     SelectOption::<String> {
-///                         index: 1usize,
+///                         tab_index: 1usize,
 ///                         value: "banana",
 ///                         "Banana"
 ///                         SelectItemIndicator { "✔️" }
@@ -142,13 +142,13 @@ pub struct SelectGroupLabelProps {
 ///                 SelectGroup {
 ///                     SelectGroupLabel { "Fruits" }
 ///                     SelectOption::<String> {
-///                         index: 0usize,
+///                         tab_index: 0usize,
 ///                         value: "apple",
 ///                         "Apple"
 ///                         SelectItemIndicator { "✔️" }
 ///                     }
 ///                     SelectOption::<String> {
-///                         index: 1usize,
+///                         tab_index: 1usize,
 ///                         value: "banana",
 ///                         "Banana"
 ///                         SelectItemIndicator { "✔️" }

--- a/primitives/src/select/components/list.rs
+++ b/primitives/src/select/components/list.rs
@@ -52,13 +52,13 @@ pub struct SelectListProps {
 ///                 SelectGroup {
 ///                     SelectGroupLabel { "Fruits" }
 ///                     SelectOption::<String> {
-///                         index: 0usize,
+///                         tab_index: 0usize,
 ///                         value: "apple",
 ///                         "Apple"
 ///                         SelectItemIndicator { "✔️" }
 ///                     }
 ///                     SelectOption::<String> {
-///                         index: 1usize,
+///                         tab_index: 1usize,
 ///                         value: "banana",
 ///                         "Banana"
 ///                         SelectItemIndicator { "✔️" }
@@ -81,7 +81,7 @@ pub fn SelectList(props: SelectListProps) -> Element {
 
     let mut open = ctx.open;
     let mut listbox_ref: Signal<Option<std::rc::Rc<MountedData>>> = use_signal(|| None);
-    let focused = move || open() && !ctx.any_focused();
+    let focused = move || open() && !ctx.focus_state.any_focused();
 
     use_effect(move || {
         let Some(listbox_ref) = listbox_ref() else {
@@ -125,19 +125,19 @@ pub fn SelectList(props: SelectListProps) -> Element {
             }
             Key::ArrowUp => {
                 arrow_key_navigation(event);
-                ctx.focus_prev();
+                ctx.focus_state.focus_prev();
             }
             Key::End => {
                 arrow_key_navigation(event);
-                ctx.focus_last();
+                ctx.focus_state.focus_last();
             }
             Key::ArrowDown => {
                 arrow_key_navigation(event);
-                ctx.focus_next();
+                ctx.focus_state.focus_next();
             }
             Key::Home => {
                 arrow_key_navigation(event);
-                ctx.focus_first();
+                ctx.focus_state.focus_first();
             }
             Key::Enter => {
                 ctx.select_current_item();
@@ -165,9 +165,9 @@ pub fn SelectList(props: SelectListProps) -> Element {
         if render() {
             if let Some(last) = (ctx.initial_focus_last)() {
                 if last {
-                    ctx.focus_last();
+                    ctx.focus_state.focus_last();
                 } else {
-                    ctx.focus_first();
+                    ctx.focus_state.focus_first();
                 }
             }
         } else {

--- a/primitives/src/select/components/list.rs
+++ b/primitives/src/select/components/list.rs
@@ -125,19 +125,19 @@ pub fn SelectList(props: SelectListProps) -> Element {
             }
             Key::ArrowUp => {
                 arrow_key_navigation(event);
-                ctx.focus_state.focus_prev();
+                ctx.focus_prev();
             }
             Key::End => {
                 arrow_key_navigation(event);
-                ctx.focus_state.focus_last();
+                ctx.focus_last();
             }
             Key::ArrowDown => {
                 arrow_key_navigation(event);
-                ctx.focus_state.focus_next();
+                ctx.focus_next();
             }
             Key::Home => {
                 arrow_key_navigation(event);
-                ctx.focus_state.focus_first();
+                ctx.focus_first();
             }
             Key::Enter => {
                 ctx.select_current_item();
@@ -163,9 +163,13 @@ pub fn SelectList(props: SelectListProps) -> Element {
 
     use_effect(move || {
         if render() {
-            ctx.focus_state.set_focus(ctx.initial_focus.cloned());
+            if (ctx.initial_focus_last)().unwrap_or_default() {
+                ctx.focus_last();
+            } else {
+                ctx.focus_first();
+            }
         } else {
-            ctx.initial_focus.set(None);
+            ctx.initial_focus_last.set(None);
         }
     });
 

--- a/primitives/src/select/components/list.rs
+++ b/primitives/src/select/components/list.rs
@@ -81,7 +81,7 @@ pub fn SelectList(props: SelectListProps) -> Element {
 
     let mut open = ctx.open;
     let mut listbox_ref: Signal<Option<std::rc::Rc<MountedData>>> = use_signal(|| None);
-    let focused = move || open() && !ctx.focus_state.any_focused();
+    let focused = move || open() && !ctx.any_focused();
 
     use_effect(move || {
         let Some(listbox_ref) = listbox_ref() else {

--- a/primitives/src/select/components/list.rs
+++ b/primitives/src/select/components/list.rs
@@ -163,10 +163,12 @@ pub fn SelectList(props: SelectListProps) -> Element {
 
     use_effect(move || {
         if render() {
-            if (ctx.initial_focus_last)().unwrap_or_default() {
-                ctx.focus_last();
-            } else {
-                ctx.focus_first();
+            if let Some(last) = (ctx.initial_focus_last)() {
+                if last {
+                    ctx.focus_last();
+                } else {
+                    ctx.focus_first();
+                }
             }
         } else {
             ctx.initial_focus_last.set(None);

--- a/primitives/src/select/components/option.rs
+++ b/primitives/src/select/components/option.rs
@@ -129,12 +129,14 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
 
     // Push this option to the context
     let mut ctx: SelectContext = use_context();
+    let disabled = ctx.disabled.cloned() || props.disabled.cloned();
     use_effect(move || {
         let option_state = OptionState {
             tab_index: index(),
             value: RcPartialEqValue::new(value.cloned()),
             text_value: text_value.cloned(),
             id: id(),
+            disabled
         };
 
         // Add the option to the context's options
@@ -147,7 +149,6 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
 
     let onmounted = use_focus_controlled_item(props.index);
     let focused = move || ctx.focus_state.is_focused(index());
-    let disabled = ctx.disabled.cloned() || props.disabled.cloned();
     let selected = use_memo(move || {
         ctx.value.read().as_ref().and_then(|v| v.as_ref::<T>()) == Some(&props.value.read())
     });
@@ -171,6 +172,9 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
                 aria_disabled: disabled,
                 aria_label: props.aria_label.clone(),
                 aria_roledescription: props.aria_roledescription.clone(),
+
+                // data attributes
+                "data-disabled": disabled,
 
                 onpointerdown: move |event| {
                     if !disabled && event.trigger_button() == Some(MouseButton::Primary) {

--- a/primitives/src/select/components/option.rs
+++ b/primitives/src/select/components/option.rs
@@ -194,7 +194,12 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
                 "data-disabled": disabled,
 
                 onpointerdown: move |event| {
-                    if !disabled && event.trigger_button() == Some(MouseButton::Primary) {
+                    if event.trigger_button() == Some(MouseButton::Primary) {
+                        if disabled {
+                            event.prevent_default();
+                            event.stop_propagation();
+                            return;
+                        }
                         ctx.set_value.call(Some(RcPartialEqValue::new(props.value.cloned())));
                         ctx.open.set(false);
                     }

--- a/primitives/src/select/components/select.rs
+++ b/primitives/src/select/components/select.rs
@@ -1,14 +1,13 @@
 //! Main Select component implementation.
 
-use core::panic;
-use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::time::Duration;
 
+use super::super::context::SelectContext;
+use crate::focus::use_focus_provider;
 use crate::{select::context::RcPartialEqValue, use_controlled, use_effect};
 use dioxus::prelude::*;
 use dioxus_core::Task;
-
-use super::super::context::SelectContext;
 
 /// Props for the main Select component
 #[derive(Props, Clone, PartialEq)]
@@ -80,13 +79,13 @@ pub struct SelectProps<T: Clone + PartialEq + 'static = String> {
 ///                 SelectGroup {
 ///                     SelectGroupLabel { "Fruits" }
 ///                     SelectOption::<String> {
-///                         index: 0usize,
+///                         tab_index: 0usize,
 ///                         value: "apple",
 ///                         "Apple"
 ///                         SelectItemIndicator { "✔️" }
 ///                     }
 ///                     SelectOption::<String> {
-///                         index: 1usize,
+///                         tab_index: 1usize,
 ///                         value: "banana",
 ///                         "Banana"
 ///                         SelectItemIndicator { "✔️" }
@@ -109,7 +108,7 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
 
     let open = use_signal(|| false);
     let mut typeahead_buffer = use_signal(String::new);
-    let options = use_signal(BTreeMap::new);
+    let options = use_signal(HashMap::new);
     let adaptive_keyboard = use_signal(super::super::text_search::AdaptiveKeyboard::new);
     let list_id = use_signal(|| None);
     let mut typeahead_clear_task: Signal<Option<Task>> = use_signal(|| None);
@@ -130,6 +129,9 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
         }
     });
 
+    let focus_state = use_focus_provider(props.roving_loop);
+    let initial_focus_last = use_signal(|| None);
+
     // Clear the typeahead buffer when the select is closed
     use_effect(move || {
         if !open() {
@@ -141,24 +143,21 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
             typeahead_buffer.take();
         }
     });
-    let initial_focus_last = use_signal(|| None);
-    let current_focus = use_signal(|| None);
 
     use_context_provider(|| SelectContext {
         typeahead_buffer,
         open,
         value,
         set_value,
-        options,
-        roving_loop: props.roving_loop,
         adaptive_keyboard,
         list_id,
         disabled: props.disabled,
         placeholder: props.placeholder,
         typeahead_clear_task,
         typeahead_timeout: props.typeahead_timeout,
+        focus_state,
+        options,
         initial_focus_last,
-        current_focus,
     });
 
     rsx! {

--- a/primitives/src/select/components/select.rs
+++ b/primitives/src/select/components/select.rs
@@ -1,6 +1,7 @@
 //! Main Select component implementation.
 
 use core::panic;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use crate::{select::context::RcPartialEqValue, use_controlled, use_effect};
@@ -8,7 +9,6 @@ use dioxus::prelude::*;
 use dioxus_core::Task;
 
 use super::super::context::SelectContext;
-use crate::focus::use_focus_provider;
 
 /// Props for the main Select component
 #[derive(Props, Clone, PartialEq)]
@@ -109,7 +109,7 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
 
     let open = use_signal(|| false);
     let mut typeahead_buffer = use_signal(String::new);
-    let options = use_signal(Vec::default);
+    let options = use_signal(BTreeMap::new);
     let adaptive_keyboard = use_signal(super::super::text_search::AdaptiveKeyboard::new);
     let list_id = use_signal(|| None);
     let mut typeahead_clear_task: Signal<Option<Task>> = use_signal(|| None);
@@ -130,8 +130,6 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
         }
     });
 
-    let focus_state = use_focus_provider(props.roving_loop);
-
     // Clear the typeahead buffer when the select is closed
     use_effect(move || {
         if !open() {
@@ -144,6 +142,7 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
         }
     });
     let initial_focus_last = use_signal(|| None);
+    let current_focus = use_signal(|| None);
 
     use_context_provider(|| SelectContext {
         typeahead_buffer,
@@ -151,14 +150,15 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
         value,
         set_value,
         options,
+        roving_loop: props.roving_loop,
         adaptive_keyboard,
         list_id,
-        focus_state,
         disabled: props.disabled,
         placeholder: props.placeholder,
         typeahead_clear_task,
         typeahead_timeout: props.typeahead_timeout,
         initial_focus_last,
+        current_focus,
     });
 
     rsx! {

--- a/primitives/src/select/components/select.rs
+++ b/primitives/src/select/components/select.rs
@@ -143,7 +143,7 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
             typeahead_buffer.take();
         }
     });
-    let initial_focus = use_signal(|| None);
+    let initial_focus_last = use_signal(|| None);
 
     use_context_provider(|| SelectContext {
         typeahead_buffer,
@@ -158,7 +158,7 @@ pub fn Select<T: Clone + PartialEq + 'static>(props: SelectProps<T>) -> Element 
         placeholder: props.placeholder,
         typeahead_clear_task,
         typeahead_timeout: props.typeahead_timeout,
-        initial_focus,
+        initial_focus_last,
     });
 
     rsx! {

--- a/primitives/src/select/components/trigger.rs
+++ b/primitives/src/select/components/trigger.rs
@@ -69,11 +69,13 @@ pub fn SelectTrigger(props: SelectTriggerProps) -> Element {
     let mut ctx = use_context::<SelectContext>();
     let mut open = ctx.open;
 
+    let focus_id = use_memo(move || ctx.current_focus_id());
+
     rsx! {
         button {
             // Standard HTML attributes
             disabled: (ctx.disabled)(),
-            type: "button",
+            r#type: "button",
 
             onclick: move |_| {
                 open.toggle();
@@ -97,9 +99,11 @@ pub fn SelectTrigger(props: SelectTriggerProps) -> Element {
             },
 
             // ARIA attributes
+            role: "combobox",
             aria_haspopup: "listbox",
             aria_expanded: open(),
             aria_controls: ctx.list_id,
+            aria_activedescendant: focus_id,
 
             // Pass through other attributes
             ..props.attributes,

--- a/primitives/src/select/components/trigger.rs
+++ b/primitives/src/select/components/trigger.rs
@@ -42,13 +42,13 @@ pub struct SelectTriggerProps {
 ///                 SelectGroup {
 ///                     SelectGroupLabel { "Fruits" }
 ///                     SelectOption::<String> {
-///                         index: 0usize,
+///                         tab_index: 0usize,
 ///                         value: "apple",
 ///                         "Apple"
 ///                         SelectItemIndicator { "✔️" }
 ///                     }
 ///                     SelectOption::<String> {
-///                         index: 1usize,
+///                         tab_index: 1usize,
 ///                         value: "banana",
 ///                         "Banana"
 ///                         SelectItemIndicator { "✔️" }
@@ -69,7 +69,7 @@ pub fn SelectTrigger(props: SelectTriggerProps) -> Element {
     let mut ctx = use_context::<SelectContext>();
     let mut open = ctx.open;
 
-    let focus_id = use_memo(move || ctx.current_focus_id());
+    let focus_id = use_memo(move || ctx.current_item_id());
 
     rsx! {
         button {

--- a/primitives/src/select/components/trigger.rs
+++ b/primitives/src/select/components/trigger.rs
@@ -82,13 +82,13 @@ pub fn SelectTrigger(props: SelectTriggerProps) -> Element {
                 match event.key() {
                     Key::ArrowUp => {
                         open.set(true);
-                        ctx.initial_focus.set(ctx.focus_state.item_count().checked_sub(1));
+                        ctx.initial_focus_last.set(Some(true));
                         event.prevent_default();
                         event.stop_propagation();
                     }
                     Key::ArrowDown => {
                         open.set(true);
-                        ctx.initial_focus.set((ctx.focus_state.item_count() > 0).then_some(0));
+                        ctx.initial_focus_last.set(Some(false));
                         event.prevent_default();
                         event.stop_propagation();
                     }

--- a/primitives/src/select/components/value.rs
+++ b/primitives/src/select/components/value.rs
@@ -80,10 +80,6 @@ pub fn SelectValue(props: SelectValueProps) -> Element {
 
     rsx! {
         // Add placeholder option if needed
-        span {
-            "data-placeholder": ctx.value.read().is_none(),
-            ..props.attributes,
-            {display_value}
-        }
+        span { "data-placeholder": ctx.value.read().is_none(), ..props.attributes, {display_value} }
     }
 }

--- a/primitives/src/select/components/value.rs
+++ b/primitives/src/select/components/value.rs
@@ -70,9 +70,9 @@ pub fn SelectValue(props: SelectValueProps) -> Element {
         value.as_ref().and_then(|v| {
             ctx.options
                 .read()
-                .iter()
-                .find(|opt| opt.value == *v)
-                .map(|opt| opt.text_value.clone())
+                .values()
+                .find(|state| state.value == *v)
+                .map(|state| state.text_value.clone())
         })
     });
 

--- a/primitives/src/select/components/value.rs
+++ b/primitives/src/select/components/value.rs
@@ -39,13 +39,13 @@ pub struct SelectValueProps {
 ///                 SelectGroup {
 ///                     SelectGroupLabel { "Fruits" }
 ///                     SelectOption::<String> {
-///                         index: 0usize,
+///                         tab_index: 0usize,
 ///                         value: "apple",
 ///                         "Apple"
 ///                         SelectItemIndicator { "✔️" }
 ///                     }
 ///                     SelectOption::<String> {
-///                         index: 1usize,
+///                         tab_index: 1usize,
 ///                         value: "banana",
 ///                         "Banana"
 ///                         SelectItemIndicator { "✔️" }

--- a/primitives/src/select/context.rs
+++ b/primitives/src/select/context.rs
@@ -69,11 +69,11 @@ pub(super) struct SelectContext {
     /// Timeout before clearing typeahead buffer
     pub typeahead_timeout: ReadSignal<Duration>,
     /// A list of options with their states
-    pub options: Signal<BTreeMap<usize, OptionState>>,
+    pub(crate) options: Signal<BTreeMap<usize, OptionState>>,
     /// If focus should loop around
     pub roving_loop: ReadSignal<bool>,
     /// The currently selected option tab_index
-    pub current_focus: Signal<Option<usize>>,
+    pub(crate) current_focus: Signal<Option<usize>>,
     /// The initial element to focus once the list is rendered<br>
     /// true: last element<br>
     /// false: first element
@@ -92,6 +92,11 @@ impl SelectContext {
 
     pub(crate) fn current_focus(&self) -> Option<usize> {
         (self.current_focus)()
+    }
+
+    pub(crate) fn current_focus_id(&self) -> Option<String> {
+        let focus = (self.current_focus)()?;
+        self.options.read().get(&focus).map(|s| s.id.clone())
     }
 
     pub(crate) fn blur(&mut self) {

--- a/primitives/src/select/mod.rs
+++ b/primitives/src/select/mod.rs
@@ -48,13 +48,13 @@
 //!                 SelectGroup {
 //!                     SelectGroupLabel { "Fruits" }
 //!                     SelectOption::<String> {
-//!                         index: 0usize,
+//!                         tab_index: 0usize,
 //!                         value: "apple",
 //!                         "Apple"
 //!                         SelectItemIndicator { "✔️" }
 //!                     }
 //!                     SelectOption::<String> {
-//!                         index: 1usize,
+//!                         tab_index: 1usize,
 //!                         value: "banana",
 //!                         "Banana"
 //!                         SelectItemIndicator { "✔️" }

--- a/primitives/src/select/text_search.rs
+++ b/primitives/src/select/text_search.rs
@@ -18,6 +18,7 @@ pub(super) fn best_match(
 
     options
         .iter()
+        .filter(|o| !o.disabled)
         .map(|opt| {
             let value = &opt.text_value;
             let value_characters: Box<[_]> = value.chars().collect();
@@ -539,18 +540,21 @@ mod tests {
                 value: RcPartialEqValue::new("apple"),
                 text_value: "Apple".to_string(),
                 id: "apple".to_string(),
+                disabled: false,
             },
             OptionState {
                 tab_index: 1,
                 value: RcPartialEqValue::new("banana"),
                 text_value: "Banana".to_string(),
                 id: "banana".to_string(),
+                disabled: false,
             },
             OptionState {
                 tab_index: 2,
                 value: RcPartialEqValue::new("cherry"),
                 text_value: "Cherry".to_string(),
                 id: "cherry".to_string(),
+                disabled: false,
             },
         ];
 
@@ -605,12 +609,14 @@ mod tests {
                 value: RcPartialEqValue::new("ф"),
                 text_value: "ф".to_string(),
                 id: "ф".to_string(),
+                disabled: false,
             },
             OptionState {
                 tab_index: 1,
                 value: RcPartialEqValue::new("banana"),
                 text_value: "Banana".to_string(),
                 id: "banana".to_string(),
+                disabled: false,
             },
         ];
 

--- a/primitives/src/select/text_search.rs
+++ b/primitives/src/select/text_search.rs
@@ -5,10 +5,10 @@ use core::f32;
 use std::collections::HashMap;
 
 /// Find the best matching option based on typeahead input
-pub(super) fn best_match(
+pub(super) fn best_match<'a>(
     keyboard: &AdaptiveKeyboard,
     typeahead: &str,
-    options: &[OptionState],
+    options: impl Iterator<Item = &'a OptionState>,
 ) -> Option<usize> {
     if typeahead.is_empty() {
         return None;
@@ -17,7 +17,6 @@ pub(super) fn best_match(
     let typeahead_characters: Box<[_]> = typeahead.chars().collect();
 
     options
-        .iter()
         .filter(|o| !o.disabled)
         .map(|opt| {
             let value = &opt.text_value;
@@ -561,19 +560,19 @@ mod tests {
         let layout = AdaptiveKeyboard::default();
 
         // Exact prefix match
-        let result = best_match(&layout, "App", &options);
+        let result = best_match(&layout, "App", options.iter());
         assert_eq!(result, Some(0));
 
         // Partial match
-        let result = best_match(&layout, "ban", &options);
+        let result = best_match(&layout, "ban", options.iter());
         assert_eq!(result, Some(1));
 
         // Empty typeahead should return None
-        let result = best_match(&layout, "", &options);
+        let result = best_match(&layout, "", options.iter());
         assert_eq!(result, None);
 
         // No match should return closest option
-        let result = best_match(&layout, "xyz", &options);
+        let result = best_match(&layout, "xyz", options.iter());
         assert!(result.is_some());
     }
 
@@ -621,11 +620,11 @@ mod tests {
         ];
 
         // ы should be a closer match to ф than banana
-        let result = best_match(&adaptive, "ф", &options);
+        let result = best_match(&adaptive, "ф", options.iter());
         assert_eq!(result, Some(0));
 
         // b should still match banana
-        let result = best_match(&adaptive, "b", &options);
+        let result = best_match(&adaptive, "b", options.iter());
         assert_eq!(result, Some(1));
     }
 

--- a/primitives/src/tabs.rs
+++ b/primitives/src/tabs.rs
@@ -299,7 +299,7 @@ pub fn TabTrigger(props: TabTriggerProps) -> Element {
         "-1"
     });
 
-    let onmounted = use_focus_controlled_item(props.index);
+    let onmounted = use_focus_controlled_item(props.index.cloned(), props.index);
 
     rsx! {
         button {

--- a/primitives/src/toggle_group.rs
+++ b/primitives/src/toggle_group.rs
@@ -239,14 +239,14 @@ pub fn ToggleItem(props: ToggleItemProps) -> Element {
             return "0";
         }
 
-        match ctx.focus.recent_focus_or_default() == props.index.cloned() {
+        match ctx.focus.recent_focus().unwrap_or_default() == props.index.cloned() {
             true => "0",
             false => "-1",
         }
     });
 
     // Handle settings focus
-    let onmounted = use_focus_controlled_item(props.index);
+    let onmounted = use_focus_controlled_item(props.index.cloned(), props.index);
 
     rsx! {
         Toggle {


### PR DESCRIPTION
This contains a lot of changes and fixes for the Select component to make disabling options properly work (see #169).

- I had to write custom `focus_prev`, `focus_last`, `focus_next`, `focus_first`, etc. functions that are independent of the ones in FocusState. This also means that i removed FocusState from the SelectContext component.
- The options Vec is now a BTreeMap, to make it easy to sort via tabindex.
- Small aria adjustments
- Additional tests 

I hope this code is up to your standards and the idea is something you are willing to use.