### PR TITLE
Replace UtcDateTime usage with wrapper function for wasm compatibility.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,6 +2248,7 @@ dependencies = [
  "num-integer",
  "time",
  "tracing",
+ "web-time",
 ]
 
 [[package]]

--- a/preview/src/components/calendar/variants/internationalized/mod.rs
+++ b/preview/src/components/calendar/variants/internationalized/mod.rs
@@ -1,13 +1,14 @@
 use super::super::component::*;
 use dioxus::prelude::*;
+use dioxus_primitives::utc_now;
 use dioxus_i18n::tid;
 
-use time::{macros::date, Date, Month, UtcDateTime, Weekday};
+use time::{macros::date, Date, Month, Weekday};
 
 #[component]
 pub fn Demo() -> Element {
     let mut selected_date = use_signal(|| None::<Date>);
-    let mut view_date = use_signal(|| UtcDateTime::now().date());
+    let mut view_date = use_signal(|| utc_now().date());
     rsx! {
         div { class: "calendar-example", style: "padding: 20px;",
             Calendar {

--- a/preview/src/components/calendar/variants/main/mod.rs
+++ b/preview/src/components/calendar/variants/main/mod.rs
@@ -1,11 +1,12 @@
 use super::super::component::*;
 use dioxus::prelude::*;
-use time::{macros::date, Date, UtcDateTime};
+use dioxus_primitives::utc_now;
+use time::{macros::date, Date};
 
 #[component]
 pub fn Demo() -> Element {
     let mut selected_date = use_signal(|| None::<Date>);
-    let mut view_date = use_signal(|| UtcDateTime::now().date());
+    let mut view_date = use_signal(|| utc_now().date());
     rsx! {
         div { class: "calendar-example", style: "padding: 20px;",
             Calendar {

--- a/preview/src/components/calendar/variants/multi_month/mod.rs
+++ b/preview/src/components/calendar/variants/multi_month/mod.rs
@@ -1,13 +1,14 @@
 use super::super::component::*;
 use dioxus::prelude::*;
-use time::{macros::date, Date, UtcDateTime};
+use dioxus_primitives::utc_now;
+use time::{macros::date, Date};
 
 use dioxus_primitives::calendar::DateRange;
 
 #[component]
 pub fn Demo() -> Element {
     let mut selected_range = use_signal(|| None::<DateRange>);
-    let mut view_date = use_signal(|| UtcDateTime::now().date());
+    let mut view_date = use_signal(|| utc_now().date());
     rsx! {
         div { class: "calendar-example", style: "padding: 20px;",
             RangeCalendar {

--- a/preview/src/components/calendar/variants/range/mod.rs
+++ b/preview/src/components/calendar/variants/range/mod.rs
@@ -1,13 +1,14 @@
 use super::super::component::*;
 use dioxus::prelude::*;
-use time::{macros::date, Date, UtcDateTime};
+use dioxus_primitives::utc_now;
+use time::{macros::date, Date};
 
 use dioxus_primitives::calendar::DateRange;
 
 #[component]
 pub fn Demo() -> Element {
     let mut selected_range = use_signal(|| None::<DateRange>);
-    let mut view_date = use_signal(|| UtcDateTime::now().date());
+    let mut view_date = use_signal(|| utc_now().date());
     rsx! {
         div { class: "calendar-example", style: "padding: 20px;",
             RangeCalendar {

--- a/preview/src/components/calendar/variants/simple/mod.rs
+++ b/preview/src/components/calendar/variants/simple/mod.rs
@@ -1,11 +1,12 @@
 use super::super::component::*;
 use dioxus::prelude::*;
-use time::{Date, UtcDateTime};
+use dioxus_primitives::utc_now;
+use time::Date;
 
 #[component]
 pub fn Demo() -> Element {
     let mut selected_date = use_signal(|| None::<Date>);
-    let mut view_date = use_signal(|| UtcDateTime::now().date());
+    let mut view_date = use_signal(|| utc_now().date());
     rsx! {
         div { class: "calendar-example", style: "padding: 20px;",
             Calendar {

--- a/preview/src/components/calendar/variants/unavailable_dates/mod.rs
+++ b/preview/src/components/calendar/variants/unavailable_dates/mod.rs
@@ -1,6 +1,7 @@
 use super::super::component::*;
 use dioxus::prelude::*;
-use time::{ext::NumericalDuration, macros::date, Date, UtcDateTime};
+use dioxus_primitives::utc_now;
+use time::{ext::NumericalDuration, macros::date, Date};
 
 use dioxus_primitives::calendar::DateRange;
 
@@ -8,7 +9,7 @@ use dioxus_primitives::calendar::DateRange;
 pub fn Demo() -> Element {
     let mut selected_range = use_signal(|| None::<DateRange>);
 
-    let now = UtcDateTime::now().date();
+    let now = utc_now().date();
     let mut view_date = use_signal(|| now);
 
     let disabled_ranges = use_signal(|| {

--- a/preview/src/components/date_picker/variants/unavailable_dates/mod.rs
+++ b/preview/src/components/date_picker/variants/unavailable_dates/mod.rs
@@ -1,14 +1,14 @@
 use super::super::component::*;
 use dioxus::prelude::*;
 
-use dioxus_primitives::calendar::DateRange;
+use dioxus_primitives::{calendar::DateRange, utc_now};
 use time::{ext::NumericalDuration, UtcDateTime};
 
 #[component]
 pub fn Demo() -> Element {
     let mut selected_range = use_signal(|| None::<DateRange>);
 
-    let now = UtcDateTime::now().date();
+    let now = utc_now().date();
     let disabled_ranges = use_signal(|| {
         vec![
             DateRange::new(now, now.saturating_add(3.days())),

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -17,6 +17,7 @@ dioxus-sdk-time = "0.7.0"
 time = { version = "0.3.44", features = ["std", "macros", "parsing"] }
 num-integer = "0.1.46"
 tracing.workspace = true
+web-time = "1.1.0"
 
 [build-dependencies]
 lazy-js-bundle = "0.6.2"

--- a/primitives/src/calendar.rs
+++ b/primitives/src/calendar.rs
@@ -7,9 +7,9 @@ use std::{
     rc::Rc,
 };
 
-use time::{ext::NumericalDuration, macros::date, Date, Month, UtcDateTime, Weekday};
+use time::{ext::NumericalDuration, macros::date, Date, Month, Weekday};
 
-use crate::date_picker::DefaultCalendarProps;
+use crate::{date_picker::DefaultCalendarProps, utc_now};
 
 // A collection of [`Weekday`]s stored as a single byte
 // Implemented as a bitmask where bits 1-7 correspond to Monday-Sunday
@@ -422,11 +422,11 @@ pub struct CalendarProps {
     pub on_format_month: Callback<Month, String>,
 
     /// The month being viewed
-    #[props(default = ReadSignal::new(Signal::new(UtcDateTime::now().date())))]
+    #[props(default = ReadSignal::new(Signal::new(utc_now().date())))]
     pub view_date: ReadSignal<Date>,
 
     /// The current date (used for highlighting today)
-    #[props(default = UtcDateTime::now().date())]
+    #[props(default = utc_now().date())]
     pub today: Date,
 
     /// Callback when view date changes
@@ -481,11 +481,12 @@ impl DefaultCalendarProps for CalendarProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarMonthTitle, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -684,11 +685,11 @@ pub struct RangeCalendarProps {
     pub on_format_month: Callback<Month, String>,
 
     /// The month being viewed
-    #[props(default = ReadSignal::new(Signal::new(UtcDateTime::now().date())))]
+    #[props(default = ReadSignal::new(Signal::new(utc_now().date())))]
     pub view_date: ReadSignal<Date>,
 
     /// The current date (used for highlighting today)
-    #[props(default = UtcDateTime::now().date())]
+    #[props(default = utc_now().date())]
     pub today: Date,
 
     /// Callback when view date changes
@@ -741,11 +742,12 @@ impl DefaultCalendarProps for RangeCalendarProps {
 /// ```rust
 /// use dioxus::prelude::*;
 /// use dioxus_primitives::calendar::*;
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_range = use_signal(|| None::<DateRange>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         RangeCalendar {
 ///             selected_range: selected_range(),
@@ -971,11 +973,12 @@ pub struct CalendarHeaderProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarMonthTitle, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1041,11 +1044,12 @@ pub struct CalendarNavigationProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarMonthTitle, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1106,11 +1110,12 @@ pub struct CalendarPreviousMonthButtonProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarMonthTitle, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1211,11 +1216,12 @@ pub struct CalendarNextMonthButtonProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarMonthTitle, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1318,11 +1324,12 @@ pub struct CalendarMonthTitleProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarMonthTitle, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1404,11 +1411,12 @@ pub struct CalendarGridProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarMonthTitle, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1563,11 +1571,12 @@ pub struct CalendarSelectMonthProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton, CalendarSelectMonth
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1683,11 +1692,12 @@ pub struct CalendarSelectYearProps {
 /// use dioxus_primitives::calendar::{
 ///     Calendar, CalendarGrid, CalendarHeader, CalendarNavigation, CalendarNextMonthButton, CalendarPreviousMonthButton, CalendarSelectYear
 /// };
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_date = use_signal(|| None::<Date>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         Calendar {
 ///             selected_date: selected_date(),
@@ -1827,11 +1837,12 @@ pub struct CalendarDayProps {
 /// ```rust
 /// use dioxus::prelude::*;
 /// use dioxus_primitives::calendar::*;
-/// use time::{Date, Month, UtcDateTime};
+/// use dioxus_primitives::utc_now;
+/// use time::{Date, Month};
 /// #[component]
 /// fn Demo() -> Element {
 ///     let mut selected_range = use_signal(|| None::<DateRange>);
-///     let mut view_date = use_signal(|| UtcDateTime::now().date());
+///     let mut view_date = use_signal(|| utc_now().date());
 ///     rsx! {
 ///         RangeCalendar {
 ///             selected_range: selected_range(),

--- a/primitives/src/date_picker.rs
+++ b/primitives/src/date_picker.rs
@@ -8,12 +8,13 @@ use crate::{
     focus::{use_focus_controlled_item, use_focus_provider, FocusState},
     popover::*,
     use_unique_id,
+    utc_now
 };
 
 use dioxus::prelude::*;
 use num_integer::Integer;
 use std::{fmt::Display, str::FromStr};
-use time::{macros::date, Date, Month, UtcDateTime, Weekday};
+use time::{macros::date, Date, Month, Weekday};
 
 /// The context provided by the [`DatePicker`] component to its children.
 #[derive(Copy, Clone)]
@@ -415,11 +416,11 @@ pub struct DatePickerCalendarProps<T: DefaultCalendarProps + Properties + Partia
     pub on_format_month: Callback<Month, String>,
 
     /// The month being viewed
-    #[props(default = ReadSignal::new(Signal::new(UtcDateTime::now().date())))]
+    #[props(default = ReadSignal::new(Signal::new(utc_now().date())))]
     pub view_date: ReadSignal<Date>,
 
     /// The current date (used for highlighting today)
-    #[props(default = UtcDateTime::now().date())]
+    #[props(default = utc_now().date())]
     pub today: Date,
 
     /// Callback when view date changes
@@ -506,7 +507,7 @@ pub fn DatePickerCalendar(props: DatePickerCalendarProps<CalendarProps>) -> Elem
 
     #[allow(non_snake_case)]
     let Calendar = props.calendar;
-    let mut view_date = use_signal(|| UtcDateTime::now().date());
+    let mut view_date = use_signal(|| utc_now().date());
     use_effect(move || {
         if let Some(date) = (ctx.selected_date)() {
             view_date.set(date);
@@ -583,7 +584,7 @@ pub fn DateRangePickerCalendar(props: DatePickerCalendarProps<RangeCalendarProps
 
     #[allow(non_snake_case)]
     let RangeCalendar = props.calendar;
-    let mut view_date = use_signal(|| UtcDateTime::now().date());
+    let mut view_date = use_signal(|| utc_now().date());
     use_effect(move || {
         if let Some(r) = (ctx.date_range)() {
             view_date.set(r.start());
@@ -904,7 +905,7 @@ fn DateElement(props: DateElementProps) -> Element {
         }
     });
 
-    let today = UtcDateTime::now().date();
+    let today = utc_now().date();
 
     let min_date = ctx.enabled_date_range.start();
     let max_date = ctx.enabled_date_range.end();

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -8,6 +8,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use dioxus::core::{current_scope_id, use_drop};
 use dioxus::prelude::*;
 use dioxus::prelude::{asset, manganis, Asset};
+use time::UtcDateTime;
+#[cfg(target_family = "wasm")]
+use web_time::SystemTime;
 
 pub mod accordion;
 pub mod alert_dialog;
@@ -43,6 +46,21 @@ pub mod toolbar;
 pub mod tooltip;
 
 pub(crate) const FOCUS_TRAP_JS: Asset = asset!("/src/js/focus-trap.js");
+
+/// Create a new UtcDateTime with the current date and time.
+///
+/// This is used as a compatibility layer for wasm targets.
+pub fn utc_now() -> UtcDateTime {
+    #[cfg(not(target_family = "wasm"))]
+    return UtcDateTime::now();
+
+    #[cfg(target_family = "wasm")]
+    {
+        let now = SystemTime::now();
+        let duration = now.duration_since(SystemTime::UNIX_EPOCH).unwrap();
+        UtcDateTime::from_unix_timestamp_nanos(duration.as_nanos().try_into().unwrap()).unwrap()
+    }
+}
 
 /// Generate a runtime-unique id.
 fn use_unique_id() -> Signal<String> {


### PR DESCRIPTION
The utc_now() function is also exported in order to be available to the importing app.

I admit this is a rather ugly workaround. Also, I am not a Rust expert. I would understand if this was not accepted.

fixes #184