### PR TITLE
Allow scrolling inside select list on mobile

### DIFF
--- a/primitives/src/select/components/option.rs
+++ b/primitives/src/select/components/option.rs
@@ -151,7 +151,7 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
     let selected = use_memo(move || {
         ctx.value.read().as_ref().and_then(|v| v.as_ref::<T>()) == Some(&props.value.read())
     });
-    let mut did_drag = use_signal(||false);
+    let mut did_drag = use_signal(|| false);
 
     use_context_provider(|| SelectOptionContext {
         selected: selected.into(),


### PR DESCRIPTION
If select list is limited in height with an overflow scroll, attempting to scroll on mobile would just click the option instead of allowing you to scroll via dragging inside list. This small proposed change fixes this.