### PR TITLE
Fix incorrect directory in README e2e test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ npx stylelint "src/**/*.css"
 To run the Playwright end-to-end tests, use:
 
 ```sh
-cd preview
+cd playwright
 npm install
 npx playwright test
 ```


### PR DESCRIPTION
The README said `cd preview` for running Playwright tests, but that's not where the `playwright.config.ts` file lives.

You can confirm by reading `.github/workflows/playwright.yml` that `cd playwright` is the correct instruction.