### PR TITLE
Fix pointer drop position in DragAndDropList

### DIFF
--- a/primitives/src/drag_and_drop_list.rs
+++ b/primitives/src/drag_and_drop_list.rs
@@ -6,8 +6,18 @@ use std::rc::Rc;
 #[derive(Clone, Copy, PartialEq, Debug)]
 enum DropPosition {
     Before,
-    After,
     Undefined,
+    After,
+}
+
+impl From<std::cmp::Ordering> for DropPosition {
+    fn from(ord: std::cmp::Ordering) -> Self {
+        match ord {
+            std::cmp::Ordering::Less => Self::Before,
+            std::cmp::Ordering::Equal => Self::Undefined,
+            std::cmp::Ordering::Greater => Self::After,
+        }
+    }
 }
 
 /// Resolves the final insertion index from a hovered item and pointer position.
@@ -26,13 +36,7 @@ fn resolve_drop_index(from: usize, hovered: usize, position: DropPosition) -> us
 
 /// Resolves whether the final insertion index is before or after the source item.
 fn resolve_drop_position(from: usize, to: usize) -> DropPosition {
-    if to < from {
-        DropPosition::Before
-    } else if to > from {
-        DropPosition::After
-    } else {
-        DropPosition::Undefined
-    }
+    to.cmp(&from).into()
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
Before this change, the drop indicator could show one position while the item was inserted in another. 
Pointer hover now resolves to the final insertion index before drop, so the indicator and final placement stay in sync.

Before:
[wrong_drop_location_before.webm](https://github.com/user-attachments/assets/651e92bf-4ffe-483a-94f4-4d334c67b890)

After:
[correct_drop_location_after.webm](https://github.com/user-attachments/assets/373f0ba0-a232-494f-b363-00b767fbb299)
