### PR TITLE
Handle cancel event as up

### DIFF
--- a/playwright/slider.spec.ts
+++ b/playwright/slider.spec.ts
@@ -24,6 +24,58 @@ test('test', async ({ page }) => {
   await expect(thumb).toHaveAttribute('aria-valuenow', '60');
 });
 
+test('drag survives pointercancel (iPad system gesture)', async ({ page }) => {
+  // iPad can fire `pointercancel` (without a following `pointerup`) when an OS
+  // gesture interrupts a drag. Regression: the slider didn't listen for
+  // `pointercancel`, so its internal "active pointer" state stayed set and
+  // every subsequent tap was ignored.
+  await page.goto('http://127.0.0.1:8080/component/?name=slider&', { timeout: 20 * 60 * 1000 });
+  const slider = page.locator('.dx-slider').first();
+  const thumb = page.locator('.dx-slider-thumb').first();
+
+  await expect(thumb).toHaveAttribute('aria-valuenow', '50');
+
+  const tap = async (frac: number, pointerId: number) => {
+    // Re-measure each time — focusing the thumb can scroll the page, which
+    // shifts the slider's viewport coordinates between taps.
+    const box = await slider.boundingBox();
+    if (!box) throw new Error('slider has no bounding box');
+    const x = box.x + box.width * frac;
+    const y = box.y + box.height / 2;
+    await slider.evaluate((el, { x, y, pointerId }) => {
+      el.dispatchEvent(new PointerEvent('pointerdown', {
+        pointerId,
+        pointerType: 'touch',
+        isPrimary: true,
+        clientX: x,
+        clientY: y,
+        button: 0,
+        buttons: 1,
+        bubbles: true,
+        cancelable: true,
+      }));
+    }, { x, y, pointerId });
+  };
+
+  // First tap at 30% sets the value normally.
+  await tap(0.3, 1);
+  await expect(thumb).toHaveAttribute('aria-valuenow', '30');
+
+  // OS gesture: pointercancel fires *without* a matching pointerup. iPad
+  // dispatches it on the captured target, not on window — bubble it from the
+  // slider element so we exercise the on-element handler too.
+  await slider.evaluate((el) => {
+    el.dispatchEvent(new PointerEvent('pointercancel', {
+      pointerId: 1,
+      bubbles: true,
+    }));
+  });
+
+  // New tap at 70% with a fresh pointer — should still update the slider.
+  await tap(0.7, 2);
+  await expect(thumb).toHaveAttribute('aria-valuenow', '70');
+});
+
 test('dynamic min/max', async ({ page }) => {
   await page.goto('http://127.0.0.1:8080/component/block?name=slider&variant=dynamic_range&', { timeout: 20 * 60 * 1000 });
   const slider = page.locator('.dx-slider');

--- a/playwright/slider.spec.ts
+++ b/playwright/slider.spec.ts
@@ -76,6 +76,59 @@ test('drag survives pointercancel (iPad system gesture)', async ({ page }) => {
   await expect(thumb).toHaveAttribute('aria-valuenow', '70');
 });
 
+test('drag ignores pageX/clientX mismatch (iPad pinch-zoom analog)', async ({ page }) => {
+  // On iPad pinch-zoomed, `e.pageX` and `e.clientX` differ by the visual
+  // viewport offset. The slider's onpointerdown stored client coords in the
+  // global POINTERS table while the window pointermove listener wrote pageX —
+  // so the very first pointermove produced a delta equal to that offset and
+  // jammed the value at 100%. Reproduce by forging pageX on synthetic events.
+  await page.goto('http://127.0.0.1:8080/component/?name=slider&', { timeout: 20 * 60 * 1000 });
+
+  const slider = page.locator('.dx-slider').first();
+  const thumb = page.locator('.dx-slider-thumb').first();
+  await expect(thumb).toHaveAttribute('aria-valuenow', '50');
+
+  const box = await slider.boundingBox();
+  if (!box) throw new Error('slider has no bounding box');
+  const x = box.x + box.width * 0.3;
+  const y = box.y + box.height / 2;
+  const pageOffset = 1000; // way larger than the slider width — would clamp to 100
+
+  // Slider's onpointerdown reads client_coordinates, so push that.
+  await slider.evaluate((el, { x, y }) => {
+    el.dispatchEvent(new PointerEvent('pointerdown', {
+      pointerId: 1,
+      pointerType: 'touch',
+      isPrimary: true,
+      clientX: x,
+      clientY: y,
+      button: 0,
+      buttons: 1,
+      bubbles: true,
+      cancelable: true,
+    }));
+  }, { x, y });
+  await expect(thumb).toHaveAttribute('aria-valuenow', '30');
+
+  // Pointermove with clientX unchanged but pageX forged so it differs.
+  // Mirrors what iPad sends when the visual viewport is offset from layout.
+  await page.evaluate(({ x, y, pageOffset }) => {
+    const evt = new PointerEvent('pointermove', {
+      pointerId: 1,
+      clientX: x,
+      clientY: y,
+      bubbles: true,
+    });
+    Object.defineProperty(evt, 'pageX', { value: x + pageOffset });
+    Object.defineProperty(evt, 'pageY', { value: y });
+    window.dispatchEvent(evt);
+  }, { x, y, pageOffset });
+
+  // Without the fix the value jumps to ~100. With consistent coords it stays.
+  const after = await thumb.getAttribute('aria-valuenow');
+  expect(parseInt(after!, 10)).toBeLessThan(50);
+});
+
 test('dynamic min/max', async ({ page }) => {
   await page.goto('http://127.0.0.1:8080/component/block?name=slider&variant=dynamic_range&', { timeout: 20 * 60 * 1000 });
   const slider = page.locator('.dx-slider');

--- a/primitives/src/slider.rs
+++ b/primitives/src/slider.rs
@@ -44,6 +44,9 @@ static POINTERS: GlobalSignal<Vec<Pointer>> = Global::new(|| {
                 });
                 window.addEventListener('pointerup', (e) => {
                     dioxus.send(['up', [e.pointerId, e.pageX, e.pageY]]);
+                });
+                window.addEventListener('pointercancel', (e) => {
+                    dioxus.send(['up', [e.pointerId, e.pageX, e.pageY]]);
                 });",
             );
 

--- a/primitives/src/slider.rs
+++ b/primitives/src/slider.rs
@@ -36,17 +36,21 @@ static POINTERS: GlobalSignal<Vec<Pointer>> = Global::new(|| {
     queue_effect(move || {
         runtime.spawn(ScopeId::ROOT, async move {
             let mut pointer_updates = dioxus::document::eval(
+                // clientX/clientY (not pageX/pageY) — must match the slider's
+                // onpointerdown which stores `evt.client_coordinates()` and the
+                // viewport-relative rect from getBoundingClientRect. On iPad
+                // with the page pinch-zoomed they diverge, jamming the slider.
                 "window.addEventListener('pointerdown', (e) => {
-                    dioxus.send(['down', [e.pointerId, e.pageX, e.pageY]]);
+                    dioxus.send(['down', [e.pointerId, e.clientX, e.clientY]]);
                 });
                 window.addEventListener('pointermove', (e) => {
-                    dioxus.send(['move', [e.pointerId, e.pageX, e.pageY]]);
+                    dioxus.send(['move', [e.pointerId, e.clientX, e.clientY]]);
                 });
                 window.addEventListener('pointerup', (e) => {
-                    dioxus.send(['up', [e.pointerId, e.pageX, e.pageY]]);
+                    dioxus.send(['up', [e.pointerId, e.clientX, e.clientY]]);
                 });
                 window.addEventListener('pointercancel', (e) => {
-                    dioxus.send(['up', [e.pointerId, e.pageX, e.pageY]]);
+                    dioxus.send(['up', [e.pointerId, e.clientX, e.clientY]]);
                 });",
             );
 

--- a/primitives/src/slider.rs
+++ b/primitives/src/slider.rs
@@ -226,6 +226,7 @@ pub fn Slider(props: SliderProps) -> Element {
         let Some(pointer) = pointers.iter().find(|p| p.id == active_pointer_id) else {
             current_pointer_id.take();
             last_processed_pos.set(None);
+            dragging.set(false);
             return;
         };
 


### PR DESCRIPTION
The slider wasn't handling client/page relative coordinates correctly which causes the slider to get stuck if you try to drag it while zoomed. This PR fixes that issue

Fixes #226