### PR TITLE
Fix multi select closing on mobile

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -61,12 +61,12 @@ export default defineConfig({
     },
 
     // Temporarily disabled mobile tests in CI. The mobile browser CI downloads acts different than the local tests which pass
-    // /* Test against mobile viewports. */
-    // {
-    //   name: "Mobile Chrome",
-    //   grep: /mobile/,
-    //   use: { ...devices["Pixel 5"] },
-    // },
+    /* Test against mobile viewports. */
+    {
+      name: "Mobile Chrome",
+      grep: /mobile/,
+      use: { ...devices["Pixel 5"] },
+    },
 
     // {
     //   name: "Mobile Safari",

--- a/playwright/select.spec.ts
+++ b/playwright/select.spec.ts
@@ -121,6 +121,31 @@ test("multi-select toggles options and stays open", async ({ page }) => {
     await expect(selectTrigger).not.toContainText("Pepperoni");
 });
 
+test("mobile: multi-select tapping options keeps the dropdown open", async ({ page }) => {
+    await page.goto("http://127.0.0.1:8080/component/?name=select&variant=multi&", {
+        timeout: 20 * 60 * 1000,
+    });
+    const selectTrigger = multiSelectTrigger(page);
+    await selectTrigger.tap();
+
+    const selectMenu = page.locator(".dx-select-list");
+    await expect(selectMenu).toHaveAttribute("data-state", "open");
+
+    const onion = selectMenu.getByRole("option", { name: "Onion" });
+    await expect(onion).toHaveAttribute("aria-selected", "false");
+
+    // Tapping the first option on mobile should toggle it without closing the menu
+    await onion.tap();
+    await expect(selectMenu).toHaveAttribute("data-state", "open");
+    await expect(onion).toHaveAttribute("aria-selected", "true");
+
+    // Tapping a second option should also leave the dropdown open
+    const pepperoni = selectMenu.getByRole("option", { name: "Pepperoni" });
+    await pepperoni.tap();
+    await expect(selectMenu).toHaveAttribute("data-state", "open");
+    await expect(pepperoni).toHaveAttribute("aria-selected", "false");
+});
+
 test("multi-select keyboard toggles and exposes aria-multiselectable", async ({ page }) => {
     await page.goto("http://127.0.0.1:8080/component/?name=select&variant=multi&", {
         timeout: 20 * 60 * 1000,

--- a/primitives/src/select/components/option.rs
+++ b/primitives/src/select/components/option.rs
@@ -190,13 +190,18 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
                     down_pos.set(Some((p.x, p.y)));
                 },
                 onpointermove: move |event| {
+                    // Drag-cancel only matters for touch; mouse clicks shouldn't be
+                    // suppressed by tiny cursor drift between down and up.
+                    if event.pointer_type() != "touch" {
+                        return;
+                    }
                     let Some((x0, y0)) = down_pos.cloned() else {
                         return;
                     };
                     let p = event.client_coordinates();
                     let dx = p.x - x0;
                     let dy = p.y - y0;
-                    // ~5px threshold tolerates trackpad jitter and small touch wobble.
+                    // ~5px threshold tolerates small touch wobble.
                     if dx * dx + dy * dy > 25.0 {
                         did_drag.set(true);
                     }

--- a/primitives/src/select/components/option.rs
+++ b/primitives/src/select/components/option.rs
@@ -155,6 +155,7 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
             .any(|v| v.as_ref::<T>() == Some(&*value))
     });
     let mut did_drag = use_signal(|| false);
+    let mut down_pos: Signal<Option<(f64, f64)>> = use_signal(|| None);
 
     use_context_provider(|| SelectOptionContext {
         selected: selected.into(),
@@ -177,28 +178,47 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
                 aria_roledescription: props.aria_roledescription.clone(),
 
                 onpointerdown: move |event| {
-                    if !disabled && &event.pointer_type() == "mouse" && event.trigger_button() == Some(MouseButton::Primary){
-                        if ctx.multi {
-                            event.prevent_default();
-                        }
-                        ctx.set_value.call(Some(RcPartialEqValue::new(props.value.cloned())));
-                        if !ctx.multi {
-                            ctx.open.set(false);
-                        }
+                    if disabled || event.trigger_button() != Some(MouseButton::Primary) {
+                        return;
                     }
-                },
-                ontouchstart: move |_| {
+                    // Suppress the synthesized focus shift and click event so the listbox
+                    // keeps DOM focus (its onblur would otherwise close us mid-tap). We
+                    // commit the selection ourselves on pointerup.
+                    event.prevent_default();
                     did_drag.set(false);
+                    let p = event.client_coordinates();
+                    down_pos.set(Some((p.x, p.y)));
                 },
-                ontouchend: move |_| {
-                    if !disabled && !did_drag(){
-                        ctx.set_value.call(Some(RcPartialEqValue::new(props.value.cloned())));
-                        if !ctx.multi {
-                            ctx.open.set(false);
-                        }
+                onpointermove: move |event| {
+                    let Some((x0, y0)) = down_pos.cloned() else {
+                        return;
+                    };
+                    let p = event.client_coordinates();
+                    let dx = p.x - x0;
+                    let dy = p.y - y0;
+                    // ~5px threshold tolerates trackpad jitter and small touch wobble.
+                    if dx * dx + dy * dy > 25.0 {
+                        did_drag.set(true);
                     }
                 },
-                ontouchmove: move |_| {
+                onpointerup: move |event| {
+                    if disabled
+                        || event.trigger_button() != Some(MouseButton::Primary)
+                        || down_pos.cloned().is_none()
+                    {
+                        return;
+                    }
+                    down_pos.set(None);
+                    if did_drag() {
+                        return;
+                    }
+                    ctx.set_value.call(Some(RcPartialEqValue::new(props.value.cloned())));
+                    if !ctx.multi {
+                        ctx.open.set(false);
+                    }
+                },
+                onpointercancel: move |_| {
+                    down_pos.set(None);
                     did_drag.set(true);
                 },
                 onblur: move |_| {

--- a/primitives/src/select/components/option.rs
+++ b/primitives/src/select/components/option.rs
@@ -191,7 +191,7 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
                     if disabled || event.trigger_button() != Some(MouseButton::Primary) {
                         return;
                     }
-                    let Some((x0, y0)) = down_pos.replace(None) else {
+                    let Some((x0, y0)) = down_pos.take() else {
                         return;
                     };
                     // Drag-cancel only matters for touch; mouse clicks shouldn't be

--- a/primitives/src/select/components/option.rs
+++ b/primitives/src/select/components/option.rs
@@ -154,7 +154,6 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
             .iter()
             .any(|v| v.as_ref::<T>() == Some(&*value))
     });
-    let mut did_drag = use_signal(|| false);
     let mut down_pos: Signal<Option<(f64, f64)>> = use_signal(|| None);
 
     use_context_provider(|| SelectOptionContext {
@@ -185,37 +184,26 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
                     // keeps DOM focus (its onblur would otherwise close us mid-tap). We
                     // commit the selection ourselves on pointerup.
                     event.prevent_default();
-                    did_drag.set(false);
                     let p = event.client_coordinates();
                     down_pos.set(Some((p.x, p.y)));
                 },
-                onpointermove: move |event| {
-                    // Drag-cancel only matters for touch; mouse clicks shouldn't be
-                    // suppressed by tiny cursor drift between down and up.
-                    if event.pointer_type() != "touch" {
+                onpointerup: move |event| {
+                    if disabled || event.trigger_button() != Some(MouseButton::Primary) {
                         return;
                     }
-                    let Some((x0, y0)) = down_pos.cloned() else {
+                    let Some((x0, y0)) = down_pos.replace(None) else {
                         return;
                     };
-                    let p = event.client_coordinates();
-                    let dx = p.x - x0;
-                    let dy = p.y - y0;
-                    // ~5px threshold tolerates small touch wobble.
-                    if dx * dx + dy * dy > 25.0 {
-                        did_drag.set(true);
-                    }
-                },
-                onpointerup: move |event| {
-                    if disabled
-                        || event.trigger_button() != Some(MouseButton::Primary)
-                        || down_pos.cloned().is_none()
-                    {
-                        return;
-                    }
-                    down_pos.set(None);
-                    if did_drag() {
-                        return;
+                    // Drag-cancel only matters for touch; mouse clicks shouldn't be
+                    // suppressed by tiny cursor drift between down and up. ~5px
+                    // threshold tolerates small touch wobble.
+                    if event.pointer_type() == "touch" {
+                        let p = event.client_coordinates();
+                        let dx = p.x - x0;
+                        let dy = p.y - y0;
+                        if dx * dx + dy * dy > 25.0 {
+                            return;
+                        }
                     }
                     ctx.set_value.call(Some(RcPartialEqValue::new(props.value.cloned())));
                     if !ctx.multi {
@@ -224,7 +212,6 @@ pub fn SelectOption<T: PartialEq + Clone + 'static>(props: SelectOptionProps<T>)
                 },
                 onpointercancel: move |_| {
                     down_pos.set(None);
-                    did_drag.set(true);
                 },
                 onblur: move |_| {
                     if focused() {


### PR DESCRIPTION
On mobile, the multi select component currently closes after selecting the first item. This PR fixes the behavior to match desktop