### PR TITLE
fix pr preview comment not showing up if the first workflow gets interrupted

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -58,8 +58,8 @@ jobs:
           clean: false
           single-commit: true
       - name: Comment PR
-        # Only run if the pr just opened
-        if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review'
+        # Post or update the preview link after a successful deploy.
+        if: github.event.action == 'opened' || github.event.action == 'reopened' || github.event.action == 'ready_for_review' || github.event.action == 'synchronize'
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |


### PR DESCRIPTION
This changes the comment workflow to always comment or update the comment on sync instead of just when the pr is opened which should fix the issue where you get no pr preview comment if the first workflow run fails