### PR TITLE
Fix focus outlines on switch, toggle and color picker

### DIFF
--- a/preview/src/components/color_picker/style.css
+++ b/preview/src/components/color_picker/style.css
@@ -86,13 +86,6 @@
     transform: translate(-50%, -50%) scale(1.15);
 }
 
-.dx-color-slider-thumb:focus-visible {
-    box-shadow:
-        black 0 0 0 1px,
-        black 0 0 0 1px inset,
-        0 0 0 4px color-mix(in oklab, var(--focused-border-color) 50%, transparent);
-}
-
 .dx-color-slider-thumb[data-dragging="true"] {
     box-shadow: black 0 0 0 1px, black 0 0 0 1px inset, rgb(0 0 0 / 30%) 0 2px 6px;
     transform: translate(-50%, -50%) scale(1.25);
@@ -134,14 +127,6 @@
 .dx-color-area-thumb:focus-visible,
 .dx-color-area-thumb:has(:focus-visible) {
     transform: translate(-50%, -50%) scale(1.15);
-}
-
-.dx-color-area-thumb:focus-visible,
-.dx-color-area-thumb:has(:focus-visible) {
-    box-shadow:
-        black 0 0 0 1px,
-        black 0 0 0 1px inset,
-        0 0 0 4px color-mix(in oklab, var(--focused-border-color) 50%, transparent);
 }
 
 .dx-color-area-thumb[data-dragging="true"] {

--- a/preview/src/components/color_picker/style.css
+++ b/preview/src/components/color_picker/style.css
@@ -86,6 +86,13 @@
     transform: translate(-50%, -50%) scale(1.15);
 }
 
+.dx-color-slider-thumb:focus-visible {
+    box-shadow:
+        black 0 0 0 1px,
+        black 0 0 0 1px inset,
+        0 0 0 4px color-mix(in oklab, var(--focused-border-color) 50%, transparent);
+}
+
 .dx-color-slider-thumb[data-dragging="true"] {
     box-shadow: black 0 0 0 1px, black 0 0 0 1px inset, rgb(0 0 0 / 30%) 0 2px 6px;
     transform: translate(-50%, -50%) scale(1.25);
@@ -129,6 +136,14 @@
     transform: translate(-50%, -50%) scale(1.15);
 }
 
+.dx-color-area-thumb:focus-visible,
+.dx-color-area-thumb:has(:focus-visible) {
+    box-shadow:
+        black 0 0 0 1px,
+        black 0 0 0 1px inset,
+        0 0 0 4px color-mix(in oklab, var(--focused-border-color) 50%, transparent);
+}
+
 .dx-color-area-thumb[data-dragging="true"] {
     box-shadow: black 0 0 0 1px, black 0 0 0 1px inset, rgb(0 0 0 / 30%) 0 2px 6px;
     transform: translate(-50%, -50%) scale(1.25);
@@ -164,6 +179,12 @@
     gap: 8px;
     line-height: 1.5;
     outline: 0 solid;
+    transition: box-shadow 150ms, background-color 150ms, color 150ms;
+}
+
+.dx-color-picker-button:focus-visible {
+    box-shadow: 0 0 0 3px
+        color-mix(in oklab, var(--focused-border-color) 50%, transparent);
 }
 
 .dx-color-picker-popover {

--- a/preview/src/components/switch/style.css
+++ b/preview/src/components/switch/style.css
@@ -13,11 +13,16 @@
   border-radius: 9999px;
   background-color: var(--primary-color-6);
   cursor: pointer;
-  transition: background-color 150ms;
+  transition: background-color 150ms, box-shadow 150ms;
 }
 
 .dx-switch[data-state="checked"] {
   background-color: var(--secondary-color-2);
+}
+
+.dx-switch:focus-visible {
+  box-shadow: 0 0 0 3px
+    color-mix(in oklab, var(--focused-border-color) 50%, transparent);
 }
 
 .dx-switch-thumb {

--- a/preview/src/components/toggle/style.css
+++ b/preview/src/components/toggle/style.css
@@ -13,11 +13,17 @@
   color: var(--secondary-color-4);
   font-size: 14px;
   outline: none;
+  transition: background-color 150ms, color 150ms, outline-color 150ms;
 }
 
 .dx-toggle:hover, .dx-toggle:focus-visible {
   background-color: var(--primary-color-4);
   cursor: pointer;
+}
+
+.dx-toggle:focus-visible {
+  outline: 2px solid var(--focused-border-color);
+  outline-offset: 2px;
 }
 
 .dx-toggle[data-state="on"] {

--- a/preview/src/components/toggle_group/style.css
+++ b/preview/src/components/toggle_group/style.css
@@ -11,7 +11,7 @@
   color: var(--secondary-color-4);
   font-size: 14px;
   outline: none;
-  transition: background-color 200ms ease, border 200ms ease;
+  transition: background-color 200ms ease, border 200ms ease, outline-color 150ms;
 }
 
 .dx-toggle-group[data-allow-multiple-pressed="true"]
@@ -30,6 +30,13 @@
 .dx-toggle-item[data-state="on"] {
   background-color: var(--primary-color-7);
   color: var(--secondary-color-1);
+}
+
+.dx-toggle-item:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--focused-border-color);
+  outline-offset: 2px;
 }
 
 .dx-toggle-group[data-allow-multiple-pressed="true"]


### PR DESCRIPTION
A couple of components were missing focus outlines making it difficult to see where you are on the page if you are using tab navigation. this pr adds focus styles