### PR TITLE
Remove backdrop transform animations

### DIFF
--- a/preview/src/components/alert_dialog/style.css
+++ b/preview/src/components/alert_dialog/style.css
@@ -4,6 +4,8 @@
   z-index: 1000;
   background: rgb(0 0 0 / 30%);
   inset: 0;
+  opacity: 0;
+  will-change: opacity;
 }
 
 .dx-alert-dialog-backdrop[data-state="closed"] {
@@ -13,12 +15,10 @@
 @keyframes dx-alert-animate-out {
   0% {
     opacity: 1;
-    transform: scale(1) translateY(0);
   }
 
   100% {
     opacity: 0;
-    transform: scale(0.95) translateY(-2px);
   }
 }
 
@@ -29,12 +29,10 @@
 @keyframes dx-alert-animate-in {
   0% {
     opacity: 0;
-    transform: scale(0.95) translateY(-2px);
   }
 
   100% {
     opacity: 1;
-    transform: scale(1) translateY(0);
   }
 }
 

--- a/preview/src/components/dialog/style.css
+++ b/preview/src/components/dialog/style.css
@@ -5,7 +5,7 @@
   background: rgb(0 0 0 / 30%);
   inset: 0;
   opacity: 0;
-  will-change: transform, opacity;
+  will-change: opacity;
 }
 
 .dx-dialog-backdrop[data-state="closed"] {
@@ -16,28 +16,24 @@
 @keyframes dx-dialog-backdrop-animate-out {
   0% {
     opacity: 1;
-    transform: scale(1) translateY(0);
   }
 
   100% {
     opacity: 0;
-    transform: scale(0.95) translateY(-2px);
   }
 }
 
 .dx-dialog-backdrop[data-state="open"] {
-  animation: dx-dialog-content-animate-in 150ms ease-out forwards;
+  animation: dx-dialog-backdrop-animate-in 150ms ease-out forwards;
 }
 
-@keyframes dx-dialog-content-animate-in {
+@keyframes dx-dialog-backdrop-animate-in {
   0% {
     opacity: 0;
-    transform: scale(0.95) translateY(-2px);
   }
 
   100% {
     opacity: 1;
-    transform: scale(1) translateY(0);
   }
 }
 


### PR DESCRIPTION
The backdrops have transform instead of just fade in transitions which looks terrible. This PR removes them